### PR TITLE
feat: section overview

### DIFF
--- a/content/en/api/actions/actions-overview.md
+++ b/content/en/api/actions/actions-overview.md
@@ -1,6 +1,7 @@
 ---
-title: Actions
-weight: 230
+title: Actions Overview
+weight: 231
+type: overview
 description: Here you'll find all about action's components and its attributes details.
 ---
 

--- a/content/en/api/actions/navigate/navigate-overview.md
+++ b/content/en/api/actions/navigate/navigate-overview.md
@@ -1,0 +1,14 @@
+---
+title: Navigate Overview
+weight: 247
+type: overview
+description: >-
+  Here you'll find action Navigate definition and pages for each of its
+  attributes
+---
+
+---
+
+Navigate is responsible to all screen's navigation on Beagle. You can configure some navigation action types, which it can be seen on the following pages. 
+
+### **Navigate Actions**

--- a/content/en/api/actions/navigate/overview.md
+++ b/content/en/api/actions/navigate/overview.md
@@ -1,6 +1,6 @@
 ---
-title: Navigate Overview
-weight: 247
+title: Overview
+weight: 1
 type: overview
 description: >-
   Here you'll find action Navigate definition and pages for each of its

--- a/content/en/api/actions/navigate/route/_index.md
+++ b/content/en/api/actions/navigate/route/_index.md
@@ -9,7 +9,3 @@ description: Description of route type
 Route defines how the navigation must be loaded.
 
 You will find below the description of the Route's types available on Beagle:
-
-### [Local]({{< ref path="/api/actions/navigate/route/local" lang="en" >}})
-
-### [Remote]({{< ref path="/api/actions/navigate/route/remote" lang="en" >}})

--- a/content/en/api/actions/navigate/route/overview.md
+++ b/content/en/api/actions/navigate/route/overview.md
@@ -1,6 +1,6 @@
 ---
-title: Route Overview
-weight: 267
+title: Overview
+weight: 1
 type: overview
 description: Description of route type
 ---

--- a/content/en/api/actions/navigate/route/route-overview.md
+++ b/content/en/api/actions/navigate/route/route-overview.md
@@ -1,0 +1,12 @@
+---
+title: Route Overview
+weight: 267
+type: overview
+description: Description of route type
+---
+
+---
+
+Route defines how the navigation must be loaded.
+
+You will find below the description of the Route's types available on Beagle:

--- a/content/en/api/actions/overview.md
+++ b/content/en/api/actions/overview.md
@@ -1,6 +1,6 @@
 ---
-title: Actions Overview
-weight: 231
+title: Overview
+weight: 1
 type: overview
 description: Here you'll find all about action's components and its attributes details.
 ---

--- a/content/en/api/components/forms/overview.md
+++ b/content/en/api/components/forms/overview.md
@@ -1,0 +1,12 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: Forms components description and its attributes details
+---
+
+---
+
+`form`  is structured by a group of components that defines how the information will be submitted and validated. 
+
+You will find below a description of all Form's attributes in a mobile or web application:

--- a/content/en/api/components/layout/overview.md
+++ b/content/en/api/components/layout/overview.md
@@ -1,0 +1,12 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: Layout components description and its attributes details
+---
+
+---
+
+Layout component can be defined with a group of 7 subcomponents: Container, Horizontal, Page View, List View, Scroll View, Stack and Vertical.   
+
+ You will find the description of every Layout attribute:

--- a/content/en/api/components/overview.md
+++ b/content/en/api/components/overview.md
@@ -1,6 +1,7 @@
 ---
-title: Components
-weight: 283
+title: Overview
+weight: 1
+type: overview
 description: Here you will find all information about components and its attributes details.
 ---
 

--- a/content/en/api/components/ui/image/overview.md
+++ b/content/en/api/components/ui/image/overview.md
@@ -1,0 +1,57 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: Here you'll find a Image description and its attributes details.
+---
+
+---
+
+## What is it?
+
+The Image widget defines a native image using server-driven data received through Beagle.
+
+Your structure is represented by the attributes below:
+
+| **Attribute** | **Type**                                                                                               | Required | **Definition**                                                      |
+| :------------ | :----------------------------------------------------------------------------------------------------- | :------- | :------------------------------------------------------------------ |
+| path          | [**ImagePath**]({{< ref path="/api/components/ui/image/imagepath" lang="en" >}}) or [**Binding**]({{< ref path="/api/context/#bindings" lang="en" >}}) | ✓        | Refers to a local image or URL of a remote image to be exhibited.   |
+| mode          | ImageContentMode                                                                                       |          | Responsible to control how the image will be internally controlled. |
+
+## How to use it?
+
+{{< tabs id="T116" >}}
+{{% tab name="JSON" %}}
+
+<!-- json-playground:imagePath.json
+{
+   "_beagleComponent_":"beagle:image",
+   "path":{
+      "_beagleImagePath_":"remote",
+      "url":"https://i.ibb.co/k9tYwtX/selo-do-exemplo-28420393.jpg",
+      "placeholder":{
+        "mobileId": "imagePath",
+        "webUrl": "/imagePath.png"
+      }
+   },
+   "mode":"CENTER"
+}
+-->
+
+{{% playground file="imagePath.json" language="en" %}}
+{{% /tab %}}
+
+{{% tab name="Kotlin DSL" %}}
+
+```kotlin
+Image(
+    path = ImagePath.Remote(
+        url = "https://i.ibb.co/k9tYwtX/selo-do-exemplo-28420393.jpg",
+        placeholder = ImagePath.Local(mobileId = "imagePath", webUrl = "/imagePath.png")
+    ),
+    mode = ImageContentMode.CENTER
+)
+```
+
+{{% /tab %}}
+{{< /tabs >}}

--- a/content/en/api/components/ui/overview.md
+++ b/content/en/api/components/ui/overview.md
@@ -1,0 +1,14 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: UI components description and its attributes details.
+---
+
+---
+
+Beagle has some components \(UI\) already ready to facilitate the process of developing an application, it is not necessary to create a customized component whenever using a component. **UI Components** are a group of building blocks used to build user interfaces or mobile user-focused interfaces. 
+
+We can also call them Widgets
+
+This category has 6 widgets:

--- a/content/en/api/context/operations/overview.md
+++ b/content/en/api/context/operations/overview.md
@@ -1,0 +1,20 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: Here you will find the complete description of Operations.
+---
+
+---
+
+## What is it? 
+
+The operations allow you to create application with more complex screens through your backend and with basic operations like addition, equals, etc. This way, the components don't need this kind of logic inside them. 
+
+## How to use it? 
+
+The operations can be used when you want to modify the values of a component through logic and operations in a different moment from the one it received the components with the JSON.
+
+On Beagle, you have some default operators and you can also create your own. 
+
+See below all the operators available on Beagle:

--- a/content/en/api/context/overview.md
+++ b/content/en/api/context/overview.md
@@ -1,0 +1,520 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: Here you'll find all about context's description
+---
+
+---
+
+## What is it?
+
+Context is a **variable of any type**, including a map that defines a set of key/value pairs. Through bindings, the value of a context can be accessed by any component or action on your scope. 
+
+The table below shows the main attributes of the context:
+
+| Attribute | Type | Required | Definition |
+| :--- | :--- | :---: | :--- |
+| id | String | ✓ | Context identifier  |
+| value | Any | ✓ | Context value |
+
+{{% alert color="info" %}}
+The context `id` can only contain letter, numbers and the character  "\_" and it must be UNIQUE on the screen. 
+{{% /alert %}}
+
+## When to use it?
+
+Context can be used when you want to fill values in a different moment from the one you received JSONs components. 
+
+On the example below, you can see a context with data of a user and it's showed some information in a `Text`: 
+
+{{< tabs id="T133" >}}
+{{% tab name="JSON" %}}
+<!-- json-playground:context.json
+{
+   "_beagleComponent_":"beagle:screenComponent",
+   "child":{
+      "_beagleComponent_":"beagle:container",
+      "children":[
+         {
+            "_beagleComponent_":"beagle:text",
+            "text":"Name: @{myData.name}"
+         },
+         {
+            "_beagleComponent_":"beagle:text",
+            "text":"Age: @{myData.age}"
+         }
+      ],
+      "context":{
+         "id":"myData",
+         "value":{
+            "id":"0000",
+            "name":"User",
+            "age":"18"
+         }
+      }
+   }
+}
+-->
+{{% playground file="context.json" language="en" %}}
+{{% /tab %}}
+
+{{% tab name="Kotlin DSL" %}}
+```text
+Container(
+    context = ContextData(
+        id = "myData",
+        value = User(
+            id = "0000"
+            name = "User",
+            age = "18"
+        )
+    ),
+    children = listOf(
+        Text("Name: @{myData.name}"),
+        Text("Age: @{myData.age}")
+    )   
+)
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Notice the context was declared and its values were defined and used to fill the texts, however it is possible to define these values after using a [`SetContext()`]({{< ref path="/api/actions/setcontext" lang="en" >}}) method.
+
+This way, you can fill the component's data that weren't yet in the JSON.
+
+{{% alert color="info" %}}
+The context is only useful if the value is accessed in any JSON part. You will need  to use `bindings` for this to happen. 
+{{% /alert %}}
+
+## How to use it? 
+
+There are two ways to use context: **explicit and implicit context**.  The main difference between them is the scope of the context, it can be defined inside the JSON or the declarative structure you are using.
+
+### Context scope
+
+The scope of a context is a component where it and its descendants were defined. It's impossible to access a declared context in another tree branch. 
+
+A context can be established in any Beagle component that implements a `ContextComponent`, that is a `context` propriety that can be specified by the following components:
+
+* `Container`
+* `Screen`
+* `ScrollView`
+* `PageView`
+* `TabView`
+* `Custom Components` that implements a `ContextComponent`
+
+### 1. Explicit Context
+
+When there is a **defined scope** to the context inside your JSON or your declarative structure. 
+
+See the example below on how it works: 
+
+{{< tabs id="T134" >}}
+{{% tab name="JSON" %}}
+<!-- json-playground:contextExplicito.json
+{
+   "_beagleComponent_":"beagle:screenComponent",
+   "child":{
+      "_beagleComponent_":"beagle:container",
+      "children":[
+         {
+            "_beagleComponent_":"beagle:text",
+            "text":"Name: @{myData.name}"
+         },
+         {
+            "_beagleComponent_":"beagle:text",
+            "text":"Age: @{myData.age}"
+         }
+      ],
+      "context":{
+         "id":"myData",
+         "value":{
+            "id":"0000",
+            "name":"User",
+            "age":"18"
+         }
+      }
+   }
+}
+-->
+{{% playground file="contextExplicito.json" language="en" %}}
+{{% /tab %}}
+
+{{% tab name="Kotlin DSL" %}}
+```kotlin
+Container(
+    context = ContextData(
+        id = "myData",
+        value = User(
+            id = "0000"
+            name = "User",
+            age = "18"
+        )
+    ),
+    children = listOf(
+        Text("Name: @{myData.name}"),
+        Text("Age: @{myData.age}")
+    )   
+)
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Notice the context was declared and its values were defined and used to fill the texts, however it is possible to define these values using the [`SetContext()`]({{< ref path="/api/actions/setcontext" lang="en" >}}) method later. You can fill the component's with data that wasn't in the JSON. 
+
+### 2. Implicit context 
+
+When there isn't a context scope defined inside a JSON or the declarative structure of your screen, but it can be accessed through **bindings**. 
+
+{{% alert color="info" %}}
+That means that this type of context is created only through **events**.
+
+Besides that, the scope on this type of context is defined only by an action or a set of action related to the created event in the context. 
+{{% /alert %}}
+
+In some cases, it's necessary to access a **particular information about an event** that triggered an action. An example is the `onChange event`, that is launched by any component and allows the data input. 
+
+If the value of an input component changes and the actions to be launched depend  on this value, it is fundamental that you have  access to the new component value. 
+
+The other implicit context characteristic is that it always have the same `id`  as the event name created it. If it the `onChange`event, for example, the context scope will have `id onChange` and the binding will be: `{ value: newValue }`, where `newValue` is the field you can include a new value to be used.
+
+Check out on the following example that used the `onBlur` event, it works the same way as `onChange`, but makes a request when the input component lost its focus: 
+
+{{< tabs id="C152" >}}
+{{% tab name="JSON" %}}
+<!-- json-playground:contextImplicit.json
+{
+   "_beagleComponent_":"beagle:screenComponent",
+   "child":{
+      "_beagleComponent_":"beagle:container",
+      "children":[
+         {
+            "_beagleComponent_":"beagle:textInput",
+            "placeholder":"ZIP",
+            "onBlur":[
+               {
+                  "_beagleAction_":"beagle:alert",
+                  "message":"example of implícit context: @{onBlur.value}"
+               }
+            ]
+         }
+      ]
+   }
+}
+-->
+{{% playground file="contextImplicit.json" language="en" %}}
+{{% /tab %}}
+
+{{% tab name="Kotlin DSL" %}}
+```kotlin
+Screen(
+        child = Container(
+            children = listOf(
+                TextInput(
+                    placeholder = "CEP",
+                    onBlur = listOf(
+                        Alert(
+                            message = "example of implicit context: @{onBlur.value}"
+                        )
+                    )
+                )
+            )
+        )
+    )
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Besides the `onBlur` context had never been declared on the example above, you can use it because it was created in an implicit way by the `onBlur` event. 
+
+The JSON defines a view where the focus lost on the CEP \(zip code\)  field runs an action to search the address based on the typed value. The request result could be used to define the value for the other fields on an address form.
+
+{{% alert color="info" %}}
+You can check an example of implicit context of Beagle Web on [**Beagle Playground**](https://beagle-playground.netlify.app/#/demo/component-interaction/address-form.json).
+{{% /alert %}}
+
+Examples of events that create an implicit context:
+
+* `onChange`
+* `onFocus`
+* `onBlur`
+* `onSuccess`
+* `onError` 
+* `onFinish`. 
+
+The first three events are part of a `beagle:textinput`component contract while the last three are part of `beagle:sendRequest` action.
+
+## Bindings
+
+Bindings are the string in a special format that **identifies a value inside a context**.  Without it is not possible to create implicit or explicit contexts.
+
+During Beagle's render process, bindings can be replaced by values referred to them.
+
+A binding is identified by a prefix `@{` and a suffix `}`. Meaning that everything between the symbols `@{` and `}` identify the context value by which the binding must be replaced when you render a screen. 
+
+See the example below on how it works: 
+
+{{< tabs id="T135" >}}
+{{% tab name="JSON" %}}
+<!-- json-playground:binding.json
+{
+  "_beagleComponent_" : "beagle:container",
+  "children" : [ {
+    "_beagleComponent_" : "beagle:text",
+    "text" : "@{myText}"
+  } ],
+  "context" : {
+    "id" : "myText",
+    "value" : "Hello Beagle"
+  }
+}
+-->
+{{% playground file="binding.json" language="en" %}}
+{{% /tab %}}
+
+{{% tab name="kotlin DSL" %}}
+```javascript
+Container(
+        children = listOf(
+            Text("@{myText}")
+        ),
+        context = ContextData(
+            id = "myText",
+            value = "Hello Beagle"
+        )
+    )
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+To access the "Hello Beagle" text through a binding, it has to specify the context id: `@{myText}`.
+
+On the example above, the context value is a simple string, but you can see on the next topic how to access values in contexts that are maps or arrays.  
+
+### Types of bindings
+
+#### Multi-valued binding \(key/value maps\) 
+
+It is the binding type which the context value it will be generally, a key/value of a map.
+
+ In these cases, bindings must be used to access substructures. As it happens in most of programming languages, Beagle uses points to make this kind of access, as you can see on the context example below:
+
+* To access the CPF, use the `@{user.cpf}` binding. 
+* To access the phone number, use the `@{user.phoneNumber.cellphone}` binding.
+
+{{< tabs id="T136" >}}
+{{% tab name="JSON" %}}
+<!-- json-playground:bindingMultiValued.json
+{
+  "_beagleComponent_" : "beagle:container",
+  "children" : [ {
+    "_beagleComponent_" : "beagle:text",
+    "text" : "@{user.phoneNumber.cellphone}"
+  } ],
+  "context" : {
+    "id" : "user",
+    "value" : {
+      "cpf" : "014.225.235-12",
+      "phoneNumber" : {
+        "cellphone" : "(34) 98856-8563",
+        "telephone" : "(34) 3214-5588"
+      }
+    }
+  }
+}
+-->
+{{% playground file="bindingMultiValued.json" language="en" %}}
+{{% /tab %}}
+
+{{% tab name="Kotlin DSL" %}}
+It's necessary to create some classes to manage multivalued contexts in Kotlin.
+
+```
+Container(
+        children = listOf(
+            Text("@{user.phoneNumber.cellphone}")
+        ),
+        context = ContextData(
+            id = "user",
+            value = User(
+                cpf = "014.225.235-12",
+                phoneNumber = PhoneNumber(
+                    cellphone = "(34) 98856-8563",
+                    telephone = "(34) 3214-5588"
+                )
+            )
+        )
+    )
+```
+
+```javascript
+data class User(val cpf: String, val phoneNumber:PhoneNumber)
+data class PhoneNumber(val cellphone:String, val telephone:String)
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+#### Binding with vectors \(arrays\)
+
+It is the type of binding which the context value will be generally vectors \(arrays\).
+
+If a vector is used on a context value, to access a specific position, you have to use the `[` e `]` characters when you're building the binding.
+
+ See how on the context example below:
+
+* To access the second film title \("Contact"\), use the `@{movies.titles[1].title}`binding. 
+
+{{< tabs id="T137" >}}
+{{% tab name="JSON" %}}
+<!-- json-playground:bindingVector.json
+{
+  "_beagleComponent_" : "beagle:container",
+  "children" : [ {
+    "_beagleComponent_" : "beagle:text",
+    "text" : "@{movies.titles[1].title}"
+  } ],
+  "context" : {
+    "id" : "movies",
+    "value" : {
+      "genre" : "sci-fi",
+      "titles" : [ {
+        "title" : "Inception",
+        "year" : "2010",
+        "rating" : "8.8"
+      }, {
+        "title" : "Contact",
+        "year" : "1997",
+        "rating" : "7.4"
+      } ]
+    }
+  }
+}
+-->
+{{% playground file="bindingVector.json" language="en" %}}
+{{% /tab %}}
+
+{{% tab name="Kotlin DSL" %}}
+It's necessary to create some classes to manage multivalued contexts in Kotlin.
+
+```text
+Container(
+    children = listOf(
+        Text("@{movies.titles[1].title}")
+    ),
+    context = ContextData(
+        id = "movies",
+        value = Movie(
+            genre = "sci-fi",
+            titles = listOf(
+                Title(
+                    title = "Inception",
+                    year = "2010",
+                    rating = "8.8"
+                ),
+                Title(
+                    title = "Contact",
+                    year = "1997",
+                    rating = "7.4"
+                )
+            )
+        )
+    )
+)
+
+```
+
+```javascript
+class Movie(val genre: String, val titles:List<Title>)
+class Title(val title:String, val year:String, val rating:String)
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+
+
+### What happens if I attribute a binding to a variable that doesn't exist?
+
+Bindings that refer to a non existent or invalid contexts cannot be updated and it will appear on the screen as they were typed \(in case the received attribute is a string\).
+
+For example, if we use  `@{client.name}` and the `"client"` context is not accessible \(declared\), this binding will be not replaced by any value. The same would happen if the "client" context doesn't exist, but has a "name" propriety. 
+
+### Multiples bindings in strings
+
+It's possible to use more than one binding in a unique string and event mix statics texts with bindings. See how on the following example:
+
+**Example:** `"Hello @{person.name}. Your score is @{score.value}."` 
+
+### Adding a support for bindings in your custom components 
+
+In each system, the binding must be declared like:
+
+* **Android:**  All the attributes receive an expression that must be declared as `Bind`. 
+* **iOS:** The attributes that receives a binding must be declared as`Expression` to have the same Android's effect. 
+* **Web:** It's not necessary to deal with bindings in a special way, which means that nothing should be done on your components.
+
+Examples for each operational system:
+
+{{< tabs id="T138" >}}
+{{% tab name="Android" %}}
+```kotlin
+data class MyComponent(
+    val text: Bind<String>
+) : WidgetView() {
+
+    override fun buildView(rootView: RootView): View {
+        val view = MyView(rootView.getContext())
+        // To make bind works you have to call the observeBindChanges method
+        // passing a rootView and the attribute that has a bind
+        observeBindChanges(rootView, text) { view.setText(it) }
+        return view
+    }
+}
+```
+{{% /tab %}}
+
+{{% tab name="iOS" %}}
+```swift
+public struct MyComponent: Widget {
+    public var widgetProperties: WidgetProperties
+
+    public let text: Expression<String>
+
+    public func toView(renderer: BeagleRenderer) -> UIView {
+        let textView = UITextView()
+
+        // To make bind works you have to call the observeBindChanges method
+        // passing a rootView and the attribute that has a bind
+        renderer.observe(text, andUpdate: \.text, in: textView)
+
+        return textView
+    }
+}
+
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+The way to refer an expression on Kotlin's DSL must be like this:
+
+{{< tabs id="T139" >}}
+{{% tab name="Kotlin DSL" %}}
+```kotlin
+MyComponent(
+  text = expressionOf("@{myContext.hello}")
+)
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+However, in case you have to pass a **hardcoded value,** you must use this way:
+
+{{< tabs id="T140" >}}
+{{% tab name="Kotlin DSL" %}}
+```kotlin
+MyComponent(
+  text = valueOf("hello")
+)
+```
+{{% /tab %}}
+{{< /tabs >}}

--- a/content/en/api/screen/overview.md
+++ b/content/en/api/screen/overview.md
@@ -1,0 +1,93 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: Here you'll find all about screen's components and its attributes details.
+---
+
+---
+
+## What is it?
+
+Your screen has attributes and components that can be used and configured. On the table below, we listed the main characteristics from each of these attributes.
+
+| **Attribute**          | **Type**                                                  | Required | **Definition**                                                                                        |
+| :--------------------- | :-------------------------------------------------------- | :------- | :---------------------------------------------------------------------------------------------------- |
+| identifier             | String                                                    |          | Attribute that globally identifies a screen in your application so you can attributes actions for it. |
+| safe area              | [**Safe Area**]({{< ref path="/api/screen/safe-area" lang="en" >}})               |          | Specifies a screen's component position.                                                              |
+| navigation bar         | [**Navigation Bar**]({{< ref path="/api/screen/navigation-bar" lang="en" >}})     |          | Allows action/navigation's bar on the screen.                                                         |
+| child                  | [**Server-Driven Component**]({{< ref path="/api/components/" lang="en" >}})      | ✓        | Define screen's elements. It can be any visual component that extends to`ServerDrivenComponent`.      |
+| style                  | [**Style**]({{< ref path="/api/widget#style-attributes" lang="en" >}})            |          | Provide visual customization options to the `screen.`                                                 |
+| screen analytics event | [**Screen Event**]({{< ref path="/api/analytics#screenview-option" lang="en" >}}) |          | Configure analytics elements to your screen.                                                          |
+| context                | [**ContextData**]({{< ref path="/api/context/" lang="en" >}})                     |          | Screen's context.                                                                                     |
+
+## How to use it?
+
+{{< tabs id="T156" >}}
+{{% tab name="JSON" %}}
+
+<!-- json-playground:screen.json
+{
+  "_beagleComponent_" : "beagle:screenComponent",
+  "navigationBar" : {
+    "title" : "Beagle Screen",
+    "showBackButton" : true,
+    "navigationBarItems" : [ {
+      "_beagleComponent_" : "beagle:navigationBarItem",
+      "text" : "",
+      "image" : {
+        "_beagleImagePath_" : "local",
+        "mobileId" : "informationImage"
+      },
+      "action" : {
+        "_beagleAction_" : "beagle:alert",
+        "title" : "Screen",
+        "message" : "Some message",
+        "labelOk" : "OK"
+      }
+    } ]
+  },
+  "child" : {
+    "_beagleComponent_" : "beagle:container",
+    "children" : [ {
+      "_beagleComponent_" : "beagle:text",
+      "text" : "Some text"
+    } ]
+  }
+}
+-->
+
+{{% playground file="screen.json" language="en" %}}
+{{% /tab %}}
+
+{{% tab name="Kotlin DSL" %}}
+
+```kotlin
+Screen(
+        navigationBar = NavigationBar(
+            title = "Beagle Screen",
+            showBackButton = true,
+            navigationBarItems = listOf(
+                NavigationBarItem(
+                    text = "",
+                    image = Local.justMobile("informationImage"),
+                    action = Alert(
+                        title = "Screen",
+                        message = "Some message",
+                        labelOk = "OK"
+                    )
+                )
+            )
+        ),
+        child = Container(
+            children = listOf(
+                Text("Some text")
+            )
+        )
+    )
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### 👉 [Test this example in the Web Playground](https://beagle-playground.netlify.app/)

--- a/content/en/get-started/creating-a-project-from-scratch/case-android/overview.md
+++ b/content/en/get-started/creating-a-project-from-scratch/case-android/overview.md
@@ -1,0 +1,330 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: 'Here, you''ll find a tutorial to start an Android project with Beagle.'
+---
+
+---
+
+## Starting an Android project
+
+For this practical example, we'll use Android Studio IDE. In case you still don't have it installed, just access on [**official Android website** ](https://developer.android.com/studio?hl=us-en)and follow the instructions.   
+  
+After you installed the program, follow the steps below:
+
+**Step 1:** Open Android Studio and click on **Start a new Android Studio project**_._ 
+
+![](https://lh4.googleusercontent.com/bAhbvEZUN_pBXavMOqCvkt2Z4NlYsxXXtmeGRKEUnyGfuIm7c-mskMhmmiMbSaCw_xonW8vceVI2C27q08-k5tV8EDD5ymvoaPwDDFGe_fN3bmoqCQEoAAKASKXOTiI3KUPI1GQ1)
+
+**Step 2:** Choose the **Empty Activity** option and click on **next**. 
+
+![](https://lh5.googleusercontent.com/nT0zkr0W_Ark0ZZDR2eWtCtfnjC_Fm98VSwU3DgBQzcgh_DoqkYNvhINztNL460p0U2hnygJ5K_DhrZMZis0mqHD69QJgKimruICs4MnBnPO9m-m_2T6E1nWIXiOfaIe0iiCjIN3)
+
+   **Step 3️:** On this page, there are some important information:
+
+* Inform your project's name. On this example, we'll call `BeagleApp`.
+* Choose which language you'll use. For Beagle, you should go with `Kotlin`.
+* Choose **SDK minimum 19**, because a lower SDK won't be compatible. 
+* Define a **package** and a **Save location** according to your preference. 
+* Click on **Next**.
+
+![](https://lh3.googleusercontent.com/m5jnbs4K5AdwQbA7YVn7fSgtVzw5S68yCbGTj_7-CYa9CGvMR-qFO5EQ4SaNehXYRmI4WOOnqA6JQouzW2QC0YMTpBq7kJSbi54yl0Q2emL_y2FizY3LyloLjuh_uDyf8WyVbodP)
+
+**Step 4️:** After you made the previous configurations, Android will take some time to build the project because it will be synchronizing all the initials dependencies to initialize the project
+
+Once the initialization is done, you will see this page: 
+
+![](/shared/mainactivity.png)
+
+{{% alert color="success" %}}
+Well done, your project was created on Android! Now, you will need to configure Beagle following the next steps. 
+{{% /alert %}}
+
+## Configuring Beagle
+
+### **Step 1:** Define the dependencies
+
+To start, you have to configure Beagle's dependencies on your repository. This can be done using the configurations below and downloading Beagle's library. 
+
+* Open your project on Android Studio.  
+* Search for `Graddle scripts` file on the project. 
+* On this file, there are two files `gradle` name. Open the first one named.`build.graddle(project:Beagle)`.
+* Search for `allprojects` code block and configure  `Maven` credentials as you see in the list below:
+
+
+```go
+// Add it in your root build.gradle at the end of repositories:
+allprojects {
+    repositories {
+        google()
+        jcenter()
+        // < 1.1.0
+        maven {
+            url 'https://dl.bintray.com/zupit/repo'
+        }
+        // >= 1.1.0
+        mavenCentral()
+    }
+}
+```
+
+
+* Close `build.graddle(project:Beagle)` file.
+
+Once you made it, we should include `kapt plugin` and `Beagle` as dependencies on `dependency manager`. To do so, follow these instructions:
+
+* Open the`build.graddle(Module:app)`  file 
+
+Notice that some `plugins` are already listed on the beginning of the file as shown below:
+
+* Then, add the line_`apply plugin: 'kotlin-kapt'`_ 
+
+![](/shared/implementacaogradle.png)
+
+After that, you need to add some dependencies: 
+
+* Search for this file that is moving in `dependencies { }`code block. 
+* Add a `ext.beagle_version` variable on the top \(in this case, out of\) the dependencies scope 
+  * The current release version of Beagle is:[![Maven Central](https://img.shields.io/maven-central/v/br.com.zup.beagle/android)](https://oss.sonatype.org/#nexus-search;gav~br.com.zup.beagle~android~~~~kw,versionexpand)
+
+Copy and paste the lines below inside your dependencies:
+
+* _implementation "br.com.zup.beagle:android:$beagle\_version"_ 
+* _kapt "br.com.zup.beagle:android-processor:$beagle\_version"_
+
+
+```go
+// Add in your app level dependency
+ext.beagle_version = "${beagle_version}"
+ 
+dependencies {
+    implementation "br.com.zup.beagle:android:$beagle_version"
+    kapt "br.com.zup.beagle:android-processor:$beagle_version"
+}
+```
+
+
+{{% alert color="info" %}}
+Add Beagle's release version instead of `${beagle.version}`, you should put Beagle's version highlighted like the blue badge above without the **v character**.
+
+For example: undefined-`ext.beagle.version = "0.2.8"`
+{{% /alert %}}
+
+At the end of these configurations, your file must be like this:
+
+![](/shared/implementacaogradle2.png)
+
+### Step 2: Configure the Android Manifest file
+
+The next step is to update your Android Manifest project by adding a few lines to the file:
+
+1. INTERNET's permission so your application can be able to access internet. `<uses-permission android:name="android.permission.INTERNET" />`
+
+{{% alert color="info" %}}
+If you find difficulties to find this or another file, just use Android Studios search bar. 
+
+To enable it, press **`SHIFT`** button twice and the search interface will appear. Once you made it, just just have to type `AndroidManifest` and Android Studio will find it. 
+{{% /alert %}}
+
+
+```markup
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.beagleexamples">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        ...
+        android:usesCleartextTraffic="true"
+        ...
+```
+
+
+Let this file open because we'll use it again in another moment.
+
+{{% alert color="warning" %}}
+* The **usesCleartextTraffic**: Indicates with the app intends to use cleartext network traffic, HTTP.  The default value for apps that target API level 27 or lower is "`true`". Apps that target API level 28 or higher default to "`false`".
+* The **attribute** `android:usesCleartextTraffic="true"` inside `<application>`tag  is used to communicate with the local BFF. Them if you intent to debug the project using a local BFF you can use this as an easy configuration step. 
+* Although, if you plan to turn this example into a release application, we recommend you to use the **`networkSecurityConfig`** which you can configure using [**android developers page instructions**](https://developer.android.com/training/articles/security-config).
+{{% /alert %}}
+
+### Step 3: Configure Network, Cache and Logger
+
+
+Now that your project is created, you must configure **Beagle** settings. To do this, follow the steps below:
+
+{{% alert color="warning" %}}
+  `Beagle` does not provide a **Network**, **Cache** or **Logger** configuration on its default components, so those must be configured for Beagle to work as expected. You can create your own defaults configurations following the examples below:
+
+  
+[**👉 Go to Network Client:**]({{< ref path="/resources/customization/beagle-for-android/network-client" lang="en" >}})
+
+[**👉 Go to Manage Cache:**]({{< ref path="/resources/customization/beagle-for-android/manage-cache" lang="en" >}})
+
+[**👉 Go to log system:**]({{< ref path="/resources/customization/beagle-for-android/log-system" lang="en" >}})
+  
+{{% /alert %}}
+
+### Step 4: Create an AppBeagleConfig
+
+For the next steps, you should create an `AppBeagleConfig` class, that is part of [**Beagle's installation**]({{< ref path="/get-started/installing-beagle/android" lang="en" >}}) and it's responsible to register some important configurations. 
+
+When you create the call, we should guarantee that it's configured in this way:
+
+* Noted with `@BeagleComponent` 
+* And extending `BeagleConfig`class. 
+
+To create AppBeagleConfig, follow these steps: 
+
+1. First, you create a package with all configurations' files.  
+2. Then, click with the right button on the main package of your project and click on **new &gt; package** __like in the image below: 
+
+![](/shared/newpackage.png)
+
+Even though you can name the file as you want to, we'll recommend for this tutorial that you use the name`beagle`.
+
+    3. Click with the right button on beagle's package and click on **new&gt;Kotlin File/Class**
+
+   __4. __Name it as `AppBeagleConfig` and then press **`ENTER`**
+
+   5. Copy and paste the configurations below on `AppBeagleConfig` file you just created. Notice that it will implement two attributes: `baseUrl` and `environment`.
+
+* The **`baseUrl`** returns the basis URL of your environment.
+* The **`environment`** returns the _`current build state`_ of your application. 
+*  **`isLoggingEnabled`** returns the application's log view 
+* The  **`cache`** manager configuration.
+
+
+```kotlin
+import br.com.zup.beagle.android.annotation.BeagleComponent
+import br.com.zup.beagle.android.setup.BeagleConfig
+import br.com.zup.beagle.android.setup.Cache
+import br.com.zup.beagle.android.setup.Environment
+
+@BeagleComponent
+class AppBeagleConfig : BeagleConfig {
+    override val baseUrl: String get() = "http://10.0.2.2:8080" // return the base url based on your environment
+    override val environment: Environment get() = Environment.DEBUG // return the current build state of your app
+    override val isLoggingEnabled: Boolean = true
+    override val cache: Cache get() = Cache(
+        enabled = true, // If true, we will cache data on disk and memory.
+        maxAge = 300, // Time in seconds that memory cache will live.
+        memoryMaximumCapacity = 15 // Memory LRU cache size. It represents number of screens that will be in memory.
+    ) // Cache management configuration
+}
+```
+
+
+{{% alert color="info" %}}
+At this tutorial point, we will test our Server-Driven screens on local host because it's important that our **`baseURL`** be local.
+
+ Now, Beagle expects that your `@BeagleComponent` classes must have only empty constructors. 
+{{% /alert %}}
+
+### **Step 5:  BeagleActivity** 
+
+Beagle offers a default `Activity` to manage all `server-driven activities`. However, it is possible to create a more specific activity to handle server-driven screens differently. You will create a new activity inherited from `BeagleActivity` and it will annotate with `@BeagleComponent`. Check more information on how to create one at the [**Beagle Activity**]({{< ref path="/resources/customization/beagle-for-android/custom-beagle-activity" lang="en" >}}) page.
+
+{{% alert color="info" %}}
+{{% /alert %}}
+
+
+
+### Step 6: Initialize Beagle and Design System 
+
+{{% alert color="info" %}}
+What is Design System? 
+
+For more information, see [**section Design System with Beagle Android**]({{< ref path="/get-started/creating-a-project-from-scratch/case-android/design-system-with-beagle-android" lang="en" >}}).
+{{% /alert %}}
+
+{{% alert color="info" %}}
+The **design system** keeps the style components registry created in the frontend and that is how your application will know which style component must be applied on each Server-Driven element. It is on the server-drive screen the visual elements \(views\) are used on the construction of your screen. 
+
+Even if you can create it now, if you want to, it is not necessary to the initial configuration in order to test Beagle faster. You can proceed without configurating it. For more information see [**Design System on  Beagle for Android**.]({{< ref path="/get-started/creating-a-project-from-scratch/case-android/design-system-with-beagle-android" lang="en" >}}) 
+{{% /alert %}}
+
+Now , you must initialize your `Application` so Beagle can manage the other configuration's files. To do so, just click on`Make project` \(HAMMER symbol\) or use the command `CTRL + F9`.
+
+![](/shared/apppackage.png)
+
+When it's initialized, Beagle will automatically create a `BeagleSetup` file that will be in the folder with the generated files, like in the image below: 
+
+![](/shared/image%20%2843%29.png)
+
+### Step 7: Create an AppApplication class
+
+On this step, you need to create a`KOTLIN` class that extends to the `Application`class. For this example, we'll name it as`AppApplication`. 
+
+It's necessary to make some configurations on this folder so it can `BeagleSetup().init(this)` function on your `onCreate` method. Follow these steps: 
+
+1. Click with the right button on your project's main package _\(_**beagleapp**_\)_ and choose:
+   * `new` &gt; `Kotlin file/class`
+   * Name the file as `AppApplication` and press **`enter`**
+   * Configure the file as in the example below: 
+
+
+```kotlin
+class AppApplication: Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        BeagleSetup().init(this)
+    }
+}
+```
+
+
+2. To finish this configuration, you must state the class on the [**AndroidManifest**](#step-2-configure-the-android-manifest-file) we created in the beginning. 
+
+The name of your`application` now it's the same of the class you created. Update the Android Manifest as it's indicated below: 
+
+
+```markup
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.beagleexamples">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:name=".AppApplication"
+        
+        ...
+```
+
+
+{{% alert color="success" %}}
+Well done, your Android application is configured and ready to use Beagle! 
+{{% /alert %}}
+
+All you have to do now is [**set up a backend** ]({{< ref path="/get-started/creating-a-project-from-scratch/case-backend" lang="en" >}})to answer your application's requests. Once you made this configuration, start your application and you'll see your first server-driven screen!
+
+### Step 8: Display your Server-Driven Screen
+
+It's very simple to show a server-driven screen. Now that all Beagle's configuration is done, you just have to follow these steps: 
+
+* Open the file `MainActivity.kt` 
+* State the `intent` as listed below. It will define the address of screen's information on the backend you configured. 
+* Copy and paste the `intent` listed below on `onCreate` method.
+
+```text
+val intent = this.newServerDrivenIntent<AppBeagleActivity>(ScreenRequest("/screen"))
+startActivity(intent)
+finish()
+```
+
+* Your`MainActivity.kt` must be like this:
+
+![](/shared/print-intent%20%281%29.png)
+
+Now you just have to click on **`Run app`** and check out your emulator's screen!   
+You will see this screen: 
+
+![](/shared/captura-de-tela-2020-06-22-a-s-11.41.12.png)
+
+{{% alert color="success" %}}
+Well done, you created your first screen with Beagle!  🎉 
+{{% /alert %}}

--- a/content/en/get-started/creating-a-project-from-scratch/case-ios/overview.md
+++ b/content/en/get-started/creating-a-project-from-scratch/case-ios/overview.md
@@ -1,0 +1,144 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: 'Here, you''ll find a tutorial to start an iOS project with Beagle.'
+---
+
+---
+
+## Starting an iOS project 
+
+To create an iOS project for Beagle, you will need a Macbook with Xcode installed. In case you don't have it yet, [**download Xcode on the Apple Store.**](https://apps.apple.com/br/app/xcode/id497799835?mt=12)
+
+Before you start, first it's necessary to create a project on `Xcode`. To do so, your just have to open the program and name a project. For this example, we'll call as **Beagle Sample.** 
+
+![](/shared/captura-de-tela-2020-04-08-a-s-10.35.19.png)
+
+After you created the project, we'll need to add the dependencies and, for that, we'll use `CocoaPods`' manager.
+
+{{% alert color="info" %}}
+If you wanna know more about how to use Cocoa Pods, [**check out their documentation.**](https://cocoapods.org/)
+{{% /alert %}}
+
+### Step 1: Configure Cocoa Pods
+
+You'll use the terminal to install `CocoaPods,` so open your terminal and type _`sudo gem install cocoapods`_
+
+```swift
+sudo gem install cocoapods
+```
+
+To configure it, go to your folder through the terminal and type: _`pod init`_ 
+
+```swift
+pod init
+```
+
+Then, open your project's folder using the _`open`_ command.
+
+```swift
+open .
+```
+
+Once you made it, you must choose the _`podfile`_ file the same way as it's shown in the image:
+
+![](https://lh3.googleusercontent.com/3zzsq_UBccpGCwaMfyYGC6KR9v4Dj4GD3LO311IOBocCIlj6N9kLiw8M6M6liCf3RnICjHpZL9Grw0JgylSSdp1jTkun-N8UYazKu7Wy0jkvBBohE6biktoz932oNFZpnf8hLrJK)
+
+Open the file and add the following dependencies:
+
+
+```swift
+target 'Beagle Sample' do
+     pod 'BeagleUI'        
+     pod 'YogaKit', :git => 'https://github.com/ZupIT/YogaKit'
+ end
+```
+
+
+Open the terminal again and type the _`pod install`_ command so your dependencies can be installed.
+
+```swift
+pod install
+```
+
+After the installation, you should open a file with a **`workspace.`** extension. For this example, we'll name it as`Beagle Sample.workspace`
+
+![](/shared/captura-de-tela-2020-04-08-a-s-10.23.09.png)
+
+### Step 2: Configure Beagle
+
+Now that your project was created, you must make **Beagle's configuration**. To do so, follow the steps below: 
+
+1. Create a class called `BeagleConfig` . 
+
+This class will be responsible to contain part of Beagle's initial configuration. You will implement a **`config`** static function on her to apply these configurations.
+
+2. On this function, create a constant called **`dependency`** that must be **`BeagleDependencies`** type. 
+
+You'll attribute to this constant some project's configurations like, for example, the list of basis URL that lists the `JSON` that will be used to build the server-driven screen. To configure this constant, use the example below:
+
+
+```swift
+import Beagle
+import Foundation
+
+class BeagleConfig {
+    static func config() {
+        
+        let dependencies = BeagleDependencies()
+        dependencies.urlBuilder = UrlBuilder(
+            baseUrl: URL(string: "http://localhost")
+        )
+        Beagle.dependencies = dependencies
+    }
+}
+```
+
+
+Now, we'll configure the **`SceneDelegate`** class so it can be used to initialize our application with Beagle from a screen through [**BFF**:]({{< ref path="/key-concepts#backend-for-frontend" lang="en" >}})
+
+* Create a **`beagleScreen`** constant, that will receive the server-driven screen. 
+* The `init URL` argument must contain the [**relative URL**]({{< ref path="/resources/urls#relative-path" lang="en" >}}) address that will be created on backend \(BFF\). For this example, we'll call it  "/screen"
+
+Follow the example below: 
+
+```swift
+let beagleScreen = Beagle.screen(.remote(.init(url: "/screen")))
+window = UIWindow(frame: UIScreen.main.bounds)
+window?.windowScene = windowScene
+window?.rootViewController = beagleScreen
+window?.makeKeyAndVisible()
+```
+
+At the end of this process, the **`SceneDelegate`** class should be like this:
+
+![](https://lh5.googleusercontent.com/JcpliGK0G3QJyLlZIDcwD8X7TZfO7QKEjCcVmWNjX0NHoS8gHl8XOZrSg6dfVntZkusNGmJxRWTa3Ps_xrhCQsIQPOzsFZ375uLqDx1qvuWJWeOnlnQkQy8EkcvMuWhJ6KU8tF-r)
+
+### Step 3: Configure Xcode
+
+Usually, the Xcode's proprieties are configured so your application can be initialized through `main.storyboard`. Now that will be done by Beagle and, for this configuration works, we must change the proprieties **deleting the references** related to `main.storyboard`. 
+
+These references are in the main project file, on**`Info tab`**, and are organized like this:
+
+The first stays in the session:   
+_**Custom iOS Target Properties**_ _**&gt;   
+`Main storyboard file base name`**_ 
+
+The second stays in the session:  
+_**`Application Scene Manifest>`**_  
+_**`Scene Configuration`&gt;**_   
+_**`Application Session Role` &gt;  
+`Item 0 (Default Configuration)`&gt;  
+`Storyboard name`**_.
+
+On the GIF below, you can see better how to remove these references:
+
+![](/shared/main%20%282%29.gif)
+
+Well done, now Beagle is configured for your iOS application! All you have to do is [**set up a backend**]({{< ref path="/get-started/creating-a-project-from-scratch/case-backend" lang="en" >}}) to answer to your server-driven application requests.
+
+Once you finished the configuration, start your application and you'll have your first server-driven screen!  
+You will see this screen: 
+
+![](/shared/captura_de_tela_2020-04-07_a-s_17-removebg-preview-2-.png)

--- a/content/en/get-started/using-beagle-helpers/android/overview.md
+++ b/content/en/get-started/using-beagle-helpers/android/overview.md
@@ -1,0 +1,35 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: 'Here you will find a library to help when you want to start a project using beagle for Android. These libs will facilitate the initial Beagle configuration in a project, avoiding some steps, and starting studies quicker.'
+---
+
+---
+
+![Maven Central](https://img.shields.io/maven-central/v/br.com.zup.beagle/beagle-scaffold?color=green&label=Beagle-Scaffold)
+![Maven Central](https://img.shields.io/maven-central/v/br.com.zup.beagle/beagle-defaults?color=green&label=Beagle-Defaults)
+![Maven Central](https://img.shields.io/maven-central/v/br.com.zup.beagle/android?label=Beagle)
+
+<hr>
+
+### Getting started
+
+To start using Beagle right now, you can use the libs below:
+* [Beagle-Scaffold]({{< ref path="/get-started/using-beagle-helpers/android/beagle-scaffold" lang="en" >}}):
+This lib will hold almost all configurations needed to start using Beagle in your project.
+We advise the use of these libs for people that never used Beagle before.
+
+* [Beagle-Defaults]({{< ref path="/get-started/using-beagle-helpers/android/beagle-defaults" lang="en" >}}):
+This lib is advised for more experienced Beagle users and 
+will hold only a few class configurations necessary to 
+use Beagle in an application. These configurations include 
+default HttpClient, Logger and Cache classes.<br>
+All these are also available in the Scaffold lib above.
+
+
+{{% alert color="warning" %}}
+If you wish to use Beagle for an application in production we advise you to configure a project
+ from scratch using our
+ [**documentation**]({{< ref path="/get-started/creating-a-project-from-scratch/case-android/" lang="en" >}})
+{{% /alert %}}

--- a/content/en/get-started/using-beagle-helpers/ios/overview.md
+++ b/content/en/get-started/using-beagle-helpers/ios/overview.md
@@ -1,0 +1,29 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: 'Here you will find libraries to help when you want to start a project using beagle for iOS.These libs will facilitate the initial Beagle configuration in a project, avoiding some steps, and starting studies quicker.'
+---
+
+---
+
+![Cocoapods](https://img.shields.io/cocoapods/v/BeagleScaffold?label=Beagle-Scaffold)
+![Cocoapods](https://img.shields.io/cocoapods/v/BeagleDefaults?label=Beagle-Defaults)
+![Cocoapods](https://img.shields.io/cocoapods/v/Beagle?label=Beagle)
+
+### Getting started
+<hr>
+
+To start using Beagle right now, you can use the libs below:
+* [Beagle-Scaffold]({{< ref path="/get-started/using-beagle-helpers/ios/beagle-scaffold" lang="en" >}}):
+This lib will hold almost all configurations needed to start using Beagle in your project.
+We advise using these libs for people that never used Beagle before.
+
+* [Beagle-Defaults]({{< ref path="/get-started/using-beagle-helpers/ios/beagle-defaults" lang="en" >}}):
+This lib is meant for more experienced Beagle users and will hold only a few class configurations necessary to use Beagle in an application. These configurations include default Network, Logger and Cache classes. All these are also available in the Scaffold lib above.
+
+{{% alert color="warning" %}}
+If you wish to use Beagle for an application in production we advise you to configure a project
+ from scratch using our
+ [**documentation**]({{< ref path="/get-started/creating-a-project-from-scratch/case-ios/" lang="en" >}})
+{{% /alert %}}

--- a/content/en/get-started/using-beagle/overview.md
+++ b/content/en/get-started/using-beagle/overview.md
@@ -1,0 +1,12 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: "Here, you'll find how to make Beagle's usage configuration for your project."
+---
+
+---
+
+After you done [**Beagle's installation**]({{< ref path="/get-started/installing-beagle/" lang="en" >}}), you have to make usage configuration to enable the tool on your project.
+
+You can make this configuration based on the platform you wanna use:

--- a/content/en/get-started/using-beagle/web/overview.md
+++ b/content/en/get-started/using-beagle/web/overview.md
@@ -1,0 +1,16 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: >-
+  Here, you'll find how to make Beagle's usage configuration for web projects on
+  Angular or React.
+---
+
+---
+
+Once you have finished [**Beagle's installation**,]({{< ref path="/get-started/installing-beagle/web" lang="en" >}}) now you can make usage configuration according to the framework you're using:
+
+{{% alert color="info" %}}
+If you wanto to use a BFF, it's necessary to have a configured CORS. **See how to do this on** [**use configurations for backend**.]({{< ref path="/get-started/using-beagle/backend#cors" lang="en" >}})
+{{% /alert %}}

--- a/content/en/playground/playground-web/overview.md
+++ b/content/en/playground/playground-web/overview.md
@@ -1,0 +1,24 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: 'Here, you''ll more information about the Playground for web.'
+---
+
+---
+
+### What is Playground? 
+
+Playground is a development tool where you can create components and pages using Beagle. It is very fast and simple, there is no installation process. It has an interface that allows you to write a JSON and instantly see the result.
+
+### Accessing **Playground**
+
+You can access the playground through the following link: 
+
+{% embed url="https://beagle-playground.netlify.app" %}}
+
+You will have access to the following demo project: 
+
+![](/shared/image%20%2827%29.png)
+
+The files menus are on the left, JSON files are centered and on the right you will see the JSON preview.

--- a/content/en/resources/cache/overview.md
+++ b/content/en/resources/cache/overview.md
@@ -1,0 +1,61 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: >-
+  Here you'll find how Beagle stores the elements in cache between the backend
+  and frontend
+---
+
+---
+
+Currently, there are **two cache labels** on Beagle:
+
+- A volatile layer.
+- A persistent layer.
+
+The volatile layer today depends on the persistent layer, meaning that only curly items on the persistent layer are candidates to the volatile cache.
+
+## Cache's layers
+
+### Volatile cache
+
+It's the cache that lays on the frontend application's memory and it's used to reduce the number of backend's calls.
+
+The entries on this cache layer has time duration defined by cache general configurations of each client's platform.
+
+You can check out how to **configure the cache** according to your frontend's platform on the following links:
+
+- [**Configuring Cache**]({{< ref path="/resources/cache/how-to-configure-cache" lang="en" >}})
+
+### Persistent cache
+
+On this cache layer, there are two types of localization:
+
+- On backend's memory;
+- On frontend's storage.
+
+This cache is used to optimize BFF's response - in terms of time and size -, in cases where there is no changes. The entries of this cache lasts until the server redeploy or the client is reinstalled.
+
+The premisse to this cache works is that it has to always return the same JSON to the same request. To guarantee that, it's necessary that this cache is the same according to its endpoint and specific platform as we can see in [**component's platform specification.**]({{< ref path="/resources/components/platform-sorting" lang="en" >}})
+
+In other words, an endpoint can return a static element because it can only work if it returns the same JSON, independently of any other specific platform.
+
+{{% alert color="danger" %}}
+It's important to remember that cache's mechanism **must not** be used with **endpoints** that does not meet this **premisse**.
+The cache can be activated or disabled on BFF by endpoint or for an entire BFF. You can **check out** [**how to configure a cache.** ]({{< ref path="/resources/cache/how-to-configure-cache" lang="en" >}})
+{{% /alert %}}
+
+## How does the cache protocol works?
+
+The protocol acts in the `beagle-hash` header. BFF validates the received hashes and send a complete response or just the `status HTTP 304 Not Modified` \(without the body\).
+
+When BFF responds with the `status 304`, the application loads the element in cache. If this does not happen, it stores the hash and render the received elements.
+
+![](/shared/beaglesave.png)
+
+## Next Steps
+
+👉 See how to [**configure cache**]({{< ref path="/resources/cache/how-to-configure-cache#configuring-and-customizing-the-cache" lang="en" >}}) according to each platform \(Android, iOS, Web e Backend\).
+
+👉Check out [**how cache works** ]({{< ref path="/resources/cache/how-to-configure-cache#how-does-cache-work" lang="en" >}})according to its types \(reliable and unreliable\).

--- a/content/en/resources/components-positioning/overview.md
+++ b/content/en/resources/components-positioning/overview.md
@@ -1,0 +1,129 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: >-
+  Here, you'll find information about how to position components on a device
+  screen using Beagle.
+---
+
+---
+
+{{% alert color="warning" %}}
+
+#### Availability: Beagle 1.0+
+
+{{% /alert %}}
+
+## Introduction
+
+Beagle will use a dependency called [**`Yoga Layout`**](https://yogalayout.com/) to position components on your application screen. To do this, Yoga calculates the position the elements are, and after that, it does its rendering.
+
+## **About Yoga Layout**
+
+Yoga is framework developed by Facebook to position views using the Flexbox concept in Android and iOS applications.
+
+Flexbox is a CSS concept that organizes elements in containers dynamically so that, regardless of your application dimensions, you can maintain a flexible layout.
+
+Here follows some key concepts about Flexbox:
+
+- **Main Axis**
+- **Cross Axis**
+- **Main Size**
+
+For Main Size, it is possible to set **3 types of dimensions:**
+
+1. **Cross Size:** The size of a cross axis.
+2. **Main Start and Main** The Start and End point in a main axis.
+3. **Cross Start and Cross End:** Start and end in a cross axis.
+
+**‌**These axis values will depend on what is defined at the Flex-direction property.
+
+If it is defined as:
+
+- **row ou row-reverse:** The main axis will be horizontal and the cross axis will be vertical.
+
+![Exemplo de yoga layout com row ou row-reverse](https://lh3.googleusercontent.com/YwCLX11cEtBYnUcVYIDy63Z_aoEA5rfErFyOKSOgxZA092HmcFO7ZwDKgKJ6Tmjr-J3m7aQgSYCn2p0QzSLO_NsibCWc7LCg9Y2xDjVXQ6BWyhIjYpB3tCdbKx-4CnrKG7tSzaqp)
+
+- **column ou column-reverse:** The main axis will be vertical and the cross axis will be horizontal.
+
+![Exemplo de yoga layout com column ou column-reverse](https://lh3.googleusercontent.com/AM1cTOExo5ux4V_2-HE6WItbPdTWHj-6CBwDXxo8mV0vZfw6WoxtWWOUtosLU_UTTAArH_pMm35geJE1HBfYjqT-DBshvLsUcjvCmVoQVdPSGTW8QCx8YJltIgC4Ad9cDKFu1dQ4)
+
+{{% alert color="info" %}}
+**Important!** The default orientation on Beagle will be a column, meaning the the elements are displayed in a column.
+{{% /alert %}}
+
+## Properties
+
+You can use the following properties that Yoga Layout uses to insert, alter or delete screen's components.
+
+### **UnitValue**
+
+The **Basis, Size, Margin, Padding and Position** attributes described above receive a `UnitValue` that expects a `Double` value and a `UnitType`, which is an `enum` with the following options:
+
+| **UnitType** | Definition                                                  |
+| :----------- | :---------------------------------------------------------- |
+| **REAL**     | Apply a `Double`value                                       |
+| **PERCENT**  | Apply a `Double` value as percentage of the parent size     |
+| **AUTO**     | Follows the parent's value. Except when it has its own size |
+
+For the attributes listed below, on the Web, the default is`UnitType.AUTO`.
+
+The `UnitType.AUTO` can be used on iOS, Android and Web fronts according to the table below:
+
+<table>
+  <thead>
+    <tr>
+      <th style="text-align:center">Attributes</th>
+      <th style="text-align:center">
+          <img src="../../.gitbook/assets/image (125).png" alt/>
+        iOS
+      </th>
+      <th style="text-align:center">
+          <img src="../../.gitbook/assets/image (126).png" alt/>
+        Android
+      </th>
+      <th style="text-align:center">
+          <img src="../../.gitbook/assets/image (122).png" alt/>
+        Web
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="text-align:center"><strong>Basis</strong>
+      </td>
+      <td style="text-align:center">&#x2714;</td>
+      <td style="text-align:center">&#x2714;</td>
+      <td style="text-align:center">&#x2714;</td>
+    </tr>
+    <tr>
+      <td style="text-align:center"><strong>Size</strong>
+      </td>
+      <td style="text-align:center"></td>
+      <td style="text-align:center"></td>
+      <td style="text-align:center">&#x2714;</td>
+    </tr>
+    <tr>
+      <td style="text-align:center"><strong>Margin</strong>
+      </td>
+      <td style="text-align:center"></td>
+      <td style="text-align:center"></td>
+      <td style="text-align:center">&#x2714;</td>
+    </tr>
+    <tr>
+      <td style="text-align:center"><strong>Padding</strong>
+      </td>
+      <td style="text-align:center"></td>
+      <td style="text-align:center"></td>
+      <td style="text-align:center">&#x2714;</td>
+    </tr>
+    <tr>
+      <td style="text-align:center"><strong>Position</strong>
+      </td>
+      <td style="text-align:center"></td>
+      <td style="text-align:center"></td>
+      <td style="text-align:center">&#x2714;</td>
+    </tr>
+  </tbody>
+</table>

--- a/content/en/resources/customization/beagle-for-android/custom-action/overview.md
+++ b/content/en/resources/customization/beagle-for-android/custom-action/overview.md
@@ -1,0 +1,24 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: >-
+  You will find here the description on how to create a Custom Action and
+  details about its methods.
+---
+
+---
+
+## Introduction
+
+`CustomAction` is a Beagle's component that can be called through events triggered by other components, including `actions`.
+
+Beagle already has some predefined actions, however it is possible to create custom actions.
+
+
+
+
+
+{{% alert color="danger" %}}
+It is **mandatory** to add the `@Transient` tag for **all attributes** present in the classes that will represent the actions so that they are not taken into account in the component serialization and deserialization.
+{{% /alert %}}

--- a/content/en/resources/customization/beagle-for-android/custom-widget/overview.md
+++ b/content/en/resources/customization/beagle-for-android/custom-widget/overview.md
@@ -1,0 +1,26 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: >-
+  You will find here an example on how to create a component and a customized
+  widget
+---
+
+---
+
+## Introduction
+
+Beagle already has **basic widgets** you can use to create interface components of your server-driven application. 
+
+However, your application may need more customized components \(Custom Views\), and to make them 'visible' to Beagle, you have to create a customized widget. You can create many new components you want, since it **makes your application's Views, 'visible' to Beagle**. 
+
+
+
+
+
+
+
+{{% alert color="danger" %}}
+It is **mandatory** to add the `@Transient` tag for **all attributes** present in the classes that will represent the widgets so that they are not taken into account in the component serialization and deserialization.
+{{% /alert %}}

--- a/content/en/resources/customization/overview.md
+++ b/content/en/resources/customization/overview.md
@@ -1,0 +1,10 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: Modifications available for each platform
+---
+
+---
+
+Beagle has in its library some customization. You can check the process of each one in the links below:

--- a/content/en/resources/style/overview.md
+++ b/content/en/resources/style/overview.md
@@ -1,0 +1,10 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: 'Here, you''ll find the style concepts according to the platform you''re using.'
+---
+
+---
+
+Beagle offers style resources for your components. You can know more about this process checking out the styles for each operational system in the next pages:

--- a/content/en/tutorials/adding-beagle-to-a-part-of-a-native-screen/overview.md
+++ b/content/en/tutorials/adding-beagle-to-a-part-of-a-native-screen/overview.md
@@ -1,0 +1,17 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: 'On this section, you will see steps to display a server-driven component on a native screen'
+---
+
+---
+
+There are two ways Beagle's components can be added to your application: 
+
+* Through BFF \(as server-driven component\);
+* As a declarative component in front end.
+
+See below more details on how to add a Beagle component in your native screen: 
+
+

--- a/content/en/tutorials/test/overview.md
+++ b/content/en/tutorials/test/overview.md
@@ -1,0 +1,98 @@
+---
+title: Overview
+weight: 1
+type: overview
+description: "In this section, you will learn more about Beagle built-in tests and tests in Beagle applications."
+---
+
+---
+
+## Unit tests
+
+Unit tests measure code functionality at its minor fraction or unit. Beagle has its own unit tests, and they should be frequently reviewed, updated or added to make sure important code units are tested.
+
+## User interface tests
+
+Beagle implements its own UI tests to make sure interface level components and their behavior work as expected. Both mobile and web platforms are tested this way and the main frameworks used are:
+- [Cucumber](https://cucumber.io/)
+- [Espresso](https://developer.android.com/training/testing/espresso)
+- [XCTest](https://developer.apple.com/documentation/xctest)
+- [Appium](http://appium.io/)
+- [Cypress](https://www.cypress.io/)
+
+
+## Mobile instrumented tests 
+
+Instrumented tests, also known as instrumented unit tests, are tests that run on physical devices or emulators, and they take advantage of APIs to forward (instrument \ orchestrate) instructions from the code to the device or emulator. These tests provide more fidelity than local unit tests, but they run slower. 
+On Beagle instrumented tests, sometimes a server-driven component doesn't or cannot have an ``ID``. In this case we add a widget element that refers to the component, and an ``ID``, so we can identify the component by the programmatically generated ``ID``.
+
+
+## Mobile Instrumented Tests: example
+
+In this example, it was implemented an instrumented test on the Android platform using Espresso framework. We verified the functionality selection and the value insertion of the server-driven text field component.
+
+ ```Kotlin
+@Test
+    public void TestSelectTextField() {
+        new BeagleRobot()
+            .checkViewContainsText("Beagle Sample")
+            .selectMenuOption()
+            .clickOnText("TextField")
+            .typeIntoTextField(0,0,"beagle")
+            ;
+    }
+````
+
+###  Step 1: Start the test
+
+You start the test validating if the application was properly opened on the main page. The function ``checkViewContainsText`` validates if the header is presented on the screen. The component used here does not have an ``ID``, so you can use the text in the header (``withText(text)``) to locate the view on the main page: 
+
+```Kotlin
+public BeagleTest checkViewContainsText(String text) {
+        onView(allOf(withText(text))).check(matches(isDisplayed()));
+        return this;
+}
+````
+
+### Step 2: Present the menu
+
+After you locate the header, the next step is to use the function ``selectMenuOption`` to select the “hamburger” icon and present the options of the menu. Since the server-driven component doesn’t have an ``ID`` for this example, you have to use the component's placement to perform this selection. This way, you search for the text on the ContentDescription with value “More options”, and then its placement on the component's hierarchy:
+
+
+```Kotlin
+public BeagleTest selectMenuOption() {
+        onView(allOf(withContentDescription("More options"), childAtPosition(childAtPosition(withId(R.id.action_bar), 1), 0))).perform(click());
+        return this;
+}
+````
+
+### Step 3: Select the component
+
+Here, the test will click on a textfield component (located from its text). The component is a menu item and it was already loaded in the previous step.
+
+```Kotlin
+public BeagleTest clickOnText(final String text) {
+        onView(allOf(withText(text), isDisplayed())).perform(click());
+        return this;
+}
+````
+### Step 4: Insert a component
+
+You will insert a text to the text field component. Since this component doesn’t have an ``ID`` or a text, it will be located by its placement in the hierarchy of the related components. Check the function ``typeIntoTextField``:
+
+```Kotlin
+public BeagleTest typeIntoTextField(int position1, int position2, String text) {
+        onView(allOf(childAtPosition(
+          childAtPosition(
+            withId(R.id.fragment_content), position1), position2)
+          )
+        ).perform(typeText(text));
+                
+        Espresso.closeSoftKeyboard();
+        return this;
+}
+````
+
+{{% alert color="success" %}}
+That’s it, the test will interact with the interface and validate the component! 
+{{% /alert %}}

--- a/content/pt/api/actions/navigate/_index.md
+++ b/content/pt/api/actions/navigate/_index.md
@@ -1,4 +1,3 @@
-
 ---
 title: Navigate
 weight: 271

--- a/content/pt/api/actions/navigate/overview.md
+++ b/content/pt/api/actions/navigate/overview.md
@@ -1,0 +1,12 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: Ações disponíveis para navegação na aplicação.
+---
+
+---
+
+O Navigate é  responsável por toda navegação de telas com Beagle. Nele, é possível configurar alguns tipos de ações de navegação, que você pode conferir nas próximas páginas. 
+
+### Ações de navegação

--- a/content/pt/api/actions/navigate/route/overview.md
+++ b/content/pt/api/actions/navigate/route/overview.md
@@ -1,0 +1,12 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: Descrição da Classe Route
+---
+
+---
+
+Route define como a navegação deve ser carregada.
+
+Abaixo, você encontra a descrição completa dos tipos de Rota disponível por padrão no Beagle:

--- a/content/pt/api/actions/overview.md
+++ b/content/pt/api/actions/overview.md
@@ -1,0 +1,36 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: Descrição dos componentes do tipo Action e seus atributos
+---
+
+---
+
+## O que é?
+
+No Beagle, uma ação lida com os comportamentos \(funções\), que serão executadas em sua aplicação assim que um determinado evento for disparado. Essas ações podem ser padrão do próprio Beagle ou customizadas.
+
+Qualquer evento no Beagle, deve ser associado a uma lista de ações. Veja abaixo um exemplo de componente de botão, que associa uma ação de alerta padrão ao seu evento de `onPress`:
+
+```javascript
+{
+   "_beagleComponent_": "beagle:button",
+   "text": "click to show alert",
+   "onPress": [{
+      "_beagleAction_": "beagle:alert",
+      "title": "Hello",
+      "message": "World"
+   }]
+}
+```
+
+Uma ação é um mapa chave/valor com pelo menos uma propriedade:`_beagleAction_`. O valor dela indica qual ação deve ser executada quando o evento for disparado. As demais propriedades especificam os parâmetros esperados pela ação indicada.
+
+Existem diversas ações implementadas no Beagle por padrão e todas elas começam com prefixo "**beagle**:" e as ações customizadas possuem o prefixo "**custom**:".
+
+Para saber como criar ações customizadas, dê uma olhada na seção de [**customização do Beagle**]({{< ref path="/tutorials/how-to-create-new-actions" lang="pt" >}})
+
+## **Tipos de ações**
+
+Abaixo, você encontra a descrição completa de cada ação disponível por padrão no Beagle:

--- a/content/pt/api/components/forms/overview.md
+++ b/content/pt/api/components/forms/overview.md
@@ -1,0 +1,12 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: Descrição dos componentes de Formulário e seus atributos
+---
+
+---
+
+O `form` \(Formulário\) é estruturado como um **grupos de componentes** que definem como as informações serão submetidas e validadas. 
+
+Abaixo você encontra uma descrição completa dos atributos que fazem parte de um **Formulário** dentro de uma aplicação mobile ou web.

--- a/content/pt/api/components/layout/overview.md
+++ b/content/pt/api/components/layout/overview.md
@@ -1,0 +1,12 @@
+---
+title: Visão geral
+weight: 1
+type: overview
+description: Descrição dos componentes de Layout e seus atributos
+---
+
+---
+
+O componente de Layout pode ser definido a partir de **7 grupos de subcomponentes**: Container, Horizontal, Page View, List View, Scroll View, Stack e Vertical.  
+
+Abaixo, você encontra uma descrição completa dos atributos que fazem parte de um Layout dentro de uma aplicação mobile ou web.

--- a/content/pt/api/components/overview.md
+++ b/content/pt/api/components/overview.md
@@ -1,6 +1,7 @@
 ---
-title: Componentes
-weight: 308
+title: Visão Geral
+weight: 1
+type: overview
 description: Descrição dos componentes e seus atributos
 ---
 

--- a/content/pt/api/components/ui/image/overview.md
+++ b/content/pt/api/components/ui/image/overview.md
@@ -1,0 +1,57 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: Descrição do componente Image e seus atributos
+---
+
+---
+
+## O que é?
+
+O widget de Imagem define uma imagem nativa usando informações server-driven recebidas por meio do Beagle.
+
+A sua estrutura é representada como mostrado abaixo:
+
+| **Atributo** | **Tipo**                                                                                                   | Obrigatório | **Definição**                                                             |
+| :----------- | :--------------------------------------------------------------------------------------------------------- | :---------: | :------------------------------------------------------------------------ |
+| path         | [**ImagePath**]({{< ref path="/api/components/ui/image/imagepath" lang="pt" >}}) ou [**Binding**]({{< ref path="/api/context#binding" lang="pt" >}}) |      ✓      | Referência de uma imagem local ou url de uma imagem remota a ser exibida. |
+| mode         | [ImageContentMode]({{< ref path="/api/components/ui/image/imagecontentmode" lang="pt" >}})                                      |             | É responsável por controlar como a imagem será controlada internamente.   |
+
+## Como usar?
+
+{{< tabs id="T134" >}}
+{{% tab name="JSON" %}}
+
+<!-- json-playground:imagePath.json
+{
+   "_beagleComponent_":"beagle:image",
+   "path":{
+      "_beagleImagePath_":"remote",
+      "url":"https://i.ibb.co/k9tYwtX/selo-do-exemplo-28420393.jpg",
+      "placeholder":{
+        "mobileId": "imagePath",
+        "webUrl": "/imagePath.png"
+      }
+   },
+   "mode":"CENTER"
+}
+-->
+
+{{% playground file="imagePath.json" language="pt" %}}
+{{% /tab %}}
+
+{{% tab name="Kotlin DSL" %}}
+
+```kotlin
+Image(
+    path = ImagePath.Remote(
+        url = "https://i.ibb.co/k9tYwtX/selo-do-exemplo-28420393.jpg",
+        placeholder = ImagePath.Local(mobileId = "imagePath", webUrl = "/imagePath.png")
+    ),
+    mode = ImageContentMode.CENTER
+)
+```
+
+{{% /tab %}}
+{{< /tabs >}}

--- a/content/pt/api/components/ui/overview.md
+++ b/content/pt/api/components/ui/overview.md
@@ -1,0 +1,14 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: Descrição dos componentes de UI e seus atributos
+---
+
+---
+
+O Beagle possui alguns componentes \(UI\) já prontos para facilitar o processo de desenvolvimento de uma aplicação, não sendo necessário criar um componente customizado sempre que for utilizar um componente. os **Componentes de UI** são um grupo de componentes básicos usados para construir as interfaces do usuário ou interfaces móveis com foco no usuário.  
+
+Também podemos chama-los de **Widgets**. 
+
+Essa categoria possui 6 widgets:

--- a/content/pt/api/context/operations/overview.md
+++ b/content/pt/api/context/operations/overview.md
@@ -1,0 +1,20 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: 'Nesta seção, você encontra descrição completa das Operações.'
+---
+
+---
+
+## O que é? 
+
+As operações permitem que você crie aplicações com telas mais complexas por meio do seu backend com operações básicas como condicionais, soma, igualdade, etc. Dessa forma, os  componentes não necessitam de ter esse tipo de lógica dentro deles. 
+
+## Como usar?
+
+De modo geral, as operações podem ser usadas quando você quer modificar os valores de um componente por meio de lógicas e operações em um momento diferente daquele em que recebeu os componentes com o JSON.
+
+No Beagle é disponibilizado alguns operadores padrões e você pode criar suas próprias operações. 
+
+Veja abaixo todos os operadores padrões oferecidos pelo Beagle:

--- a/content/pt/api/context/overview.md
+++ b/content/pt/api/context/overview.md
@@ -1,0 +1,545 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: "Nesta seção, você encontra descrição completa de contexto."
+---
+
+---
+
+## O que é?
+
+O contexto é uma **variável de qualquer tipo**, incluindo o mapa que define um conjunto de pares de chaves/valores. Por meio de **bindings**, o valor do contexto pode ser acessado por qualquer componente ou ação do seu escopo.
+
+A tabela abaixo demonstra os principais atributos do contexto:
+
+| Atributo | Tipo   | Obrigatoriedade | Definição                 |
+| :------- | :----- | :-------------: | :------------------------ |
+| id       | String |        ✓        | Identificador do contexto |
+| value    | Any    |        ✓        | Valor do contexto         |
+
+{{% alert color="info" %}}
+No caso do contexto id, é importante que ele tenha apenas letras, números e o caractere "\_" e deve ser ÚNICO na tela.
+{{% /alert %}}
+
+## Quando usar?
+
+De modo geral, o contexto pode ser usado quando você quer preencher valores em um momento diferente daquele em que recebeu os componentes com o JSON.
+
+No exemplo abaixo, você pode ver o contexto com dados de um usuário e sendo mostrados algumas dessas informações em um `Text` :
+
+{{< tabs id="T151" >}}
+{{% tab name="JSON" %}}
+
+<!-- json-playground:context.json
+{
+   "_beagleComponent_":"beagle:screenComponent",
+   "child":{
+      "_beagleComponent_":"beagle:container",
+      "children":[
+         {
+            "_beagleComponent_":"beagle:text",
+            "text":"Name: @{myData.name}"
+         },
+         {
+            "_beagleComponent_":"beagle:text",
+            "text":"Age: @{myData.age}"
+         }
+      ],
+      "context":{
+         "id":"myData",
+         "value":{
+            "id":"0000",
+            "name":"User",
+            "age":"18"
+         }
+      }
+   }
+}
+-->
+
+{{% playground file="context.json" language="pt" %}}
+{{% /tab %}}
+
+{{% tab name="Kotlin DSL" %}}
+
+```text
+Container(
+    context = ContextData(
+        id = "myData",
+        value = User(
+            id = "0000"
+            name = "User",
+            age = "18"
+        )
+    ),
+    children = listOf(
+        Text("Name: @{myData.name}"),
+        Text("Age: @{myData.age}")
+    )
+)
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+Perceba que o contexto foi declarado e seus valores foram definidos e usados para preencher os textos, porém é possível definir esses valores depois usando o método [`SetContext()`]({{< ref path="/api/actions/setcontext" lang="pt" >}}).
+
+Dessa forma, você pode preencher os componentes com dados que ainda não estavam no JSON.
+
+{{% alert color="info" %}}
+O contexto só é útil se o valor for acessado em qualquer parte do JSON. Para isso acontecer, você precisa usar o `bindings`.
+{{% /alert %}}
+
+## Como usar?
+
+Há duas formas para usar contexto: **contexto explícito e implícito**. A principal diferença entre eles é o escopo do contexto, que pode \(ou não\) ser definido dentro do JSON ou da estrutura declarativa que estiver usando.
+
+### Escopo do contexto
+
+O escopo de um contexto é o componente no qual seus descendentes são definidos. Isso torna possível acessar o contexto declarado em uma outra branch da árvore.
+
+Um contexto pode ser estabelecido em qualquer componente do Beagle que implementa o `ContextComponent`, que é a propriedade do `context` que pode especificar os seguintes componentes:
+
+- `Container`
+- `Screen`
+- `ScrollView`
+- `PageView`
+- `TabView`
+- `Custom Components`, que implementa o `ContextComponent`
+
+### 1. Contexto explícito
+
+Quando **há um escopo definido** para o contexto dentro do seu JSON ou da sua estrutura declarativa.
+
+Veja o exemplo abaixo de como funciona:
+
+{{< tabs id="T152" >}}
+{{% tab name="JSON" %}}
+
+<!-- json-playground:contextExplicito.json
+{
+   "_beagleComponent_":"beagle:screenComponent",
+   "child":{
+      "_beagleComponent_":"beagle:container",
+      "children":[
+         {
+            "_beagleComponent_":"beagle:text",
+            "text":"Name: @{myData.name}"
+         },
+         {
+            "_beagleComponent_":"beagle:text",
+            "text":"Age: @{myData.age}"
+         }
+      ],
+      "context":{
+         "id":"myData",
+         "value":{
+            "id":"0000",
+            "name":"User",
+            "age":"18"
+         }
+      }
+   }
+}
+-->
+
+{{% playground file="contextExplicito.json" language="pt" %}}
+{{% /tab %}}
+
+{{% tab name="Kotlin DSL" %}}
+
+```kotlin
+Container(
+    context = ContextData(
+        id = "myData",
+        value = User(
+            id = "0000"
+            name = "User",
+            age = "18"
+        )
+    ),
+    children = listOf(
+        Text("Name: @{myData.name}"),
+        Text("Age: @{myData.age}")
+    )
+)
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+Perceba que o contexto foi declarado e seus valores foram definidos e usados para preencher os textos, porém é possível definir depois esses valores usando o método [`SetContext()`]({{< ref path="/api/actions/setcontext" lang="pt" >}}) . Dessa forma, você pode preencher os componentes com dados que ainda não estavam no JSON.
+
+### 2. Contextos implícitos
+
+Quando **não há um escopo** de contexto definido dentro do JSON ou da estrutura declarativa da sua tela, mas que podem ser acessados por [**bindings**](#binding).
+
+{{% alert color="info" %}}
+Isso significa que esse tipo de contexto é criado por meio de [**eventos**]({{< ref path="/api/events" lang="pt" >}}).
+
+Além disso, o escopo desse tipo de contexto é definido apenas por uma action ou um conjunto de ações relacionados ao evento criado no contexto.
+{{% /alert %}}
+
+Em alguns casos, é necessário acessar uma **informação específica sobre um evento** que engatilhou uma ação. Um exemplo comum é o `onChange event`, que é lançado por qualquer componente e permite a entrada de dados.
+
+Caso mude o valor de uma entrada de um componente e as ações a serem lançadas dependem desse valor, é fundamental que você tenha acesso ao novo valor do componente.
+
+Outra característica do contexto implícito é que ele sempre possui um `id` igual ao nome do evento criado. Se, por exemplo, o evento é o onCharge, o escopo do contexto terá `id onChange` e binding ficará dessa forma:`{ value: newValue },` no qual `newValue` é o campo que você pode incluir um novo valor a ser usado.
+
+Veja o exemplo abaixo com o evento `onBlur` , que funciona exatamente como o `onChange`, mas faz a requisição quando o input do componente perde o foco:
+
+{{< tabs id="C152" >}}
+{{% tab name="JSON" %}}
+
+<!-- json-playground:contextImplicito.json
+{
+   "_beagleComponent_":"beagle:screenComponent",
+   "child":{
+      "_beagleComponent_":"beagle:container",
+      "children":[
+         {
+            "_beagleComponent_":"beagle:textInput",
+            "placeholder":"CEP",
+            "onBlur":[
+               {
+                  "_beagleAction_":"beagle:alert",
+                  "message":"example of implícit context: @{onBlur.value}"
+               }
+            ]
+         }
+      ]
+   }
+}
+-->
+
+{{% playground file="contextImplicito.json" language="pt" %}}
+{{% /tab %}}
+
+{{% tab name="Kotlin DSL" %}}
+
+```kotlin
+Screen(
+        child = Container(
+            children = listOf(
+                TextInput(
+                    placeholder = "CEP",
+                    onBlur = listOf(
+                        Alert(
+                            message = "example of implícit context: @{onBlur.value}"
+                        )
+                    )
+                )
+            )
+        )
+    )
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+Apesar do contexto `onBlur` não ter sido declarado no exemplo acima, você consegue usá-lo porque ele foi criado de uma maneira implícita pelo evento `onBlur`.
+
+O que acontece é que o JSON define a view onde o foco se perdeu no campo de CEP e a ação é rodada para procurar o endereço com base no valor digitado. O resultado da requisição pode ser usado para definir o valor de outros campos no formulário de endereço.
+
+{{% alert color="info" %}}
+Você pode conferir um exemplo de uso de contexto implícito no Beagle Web no [**Beagle Playground**](https://beagle-playground.netlify.app/#/demo/component-interaction/address-form.json).
+{{% /alert %}}
+
+Exemplos de eventos criados com contexto implícito:
+
+- `onChange`
+- `onFocus`
+- `onBlur`
+- `onSuccess`
+- `onError`
+- `onFinish`
+
+Os três primeiros eventos são parte do contrato do componente `beagle:textinput` enquanto os três últimos são parte da ação `beagle:sendRequest` .
+
+## Binding
+
+O binding é a string em um formato especial, que **identifica o valor dentro de um contexto**. Sem ele, não é possível criar contextos, sejam eles implícitos ou explícitos.
+
+Durante o processo de renderização do Beagle, bindings podem ser substituídos pelos valores que são referenciados a ele.
+
+Um binding é identificado com o prefixo**`@{`** e o sufixo **`}`**. Isso significa que tudo entre esses símbolos serve como uma expressão do contexto, que deve ser substituído quando você renderizar a tela.
+
+Veja o exemplo abaixo de como funciona:
+
+{{< tabs id="T153" >}}
+{{% tab name="JSON" %}}
+
+<!-- json-playground:binding.json
+{
+  "_beagleComponent_" : "beagle:container",
+  "children" : [ {
+    "_beagleComponent_" : "beagle:text",
+    "text" : "@{myText}"
+  } ],
+  "context" : {
+    "id" : "myText",
+    "value" : "Hello Beagle"
+  }
+}
+-->
+
+{{% playground file="binding.json" language="pt" %}}
+{{% /tab %}}
+
+{{% tab name="kotlin DSL" %}}
+
+```javascript
+Container(
+  (children = listOf(Text("@{myText}"))),
+  (context = ContextData((id = "myText"), (value = "Hello Beagle")))
+);
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+Para acessar o texto "Hello Beagle" por meio de bindings, é preciso especificar o id do contexto: `@{myText}`.
+
+No exemplo acima, o valor do contexto é uma simples string, mas você pode ver nos tópicos a seguir como acessar valores em contextos que são mapas ou arrays.
+
+### Tipos de Bindings
+
+#### Binding multi-valorados \(key/value maps\)
+
+É o tipo de binding no qual o valor do contexto será, geralmente, uma chave/valor de um map \(key/value map\).
+
+Nesses casos, os bindings devem ser usados para acessar subestruturas. Como acontece na maior parte de linguagens de programação, o Beagle usa pontos para fazer esse tipo de acesso, como você pode ver no exemplo abaixo:
+
+- Para acessar o CPF, use o binding `@{user.cpf}` ;
+- Para acessar o número de telefone, use o binding `@{user.phoneNumber.cellphone}`.
+
+{{< tabs id="T154" >}}
+{{% tab name="JSON" %}}
+
+<!-- json-playground:bindingMultiValorados.json
+{
+  "_beagleComponent_" : "beagle:container",
+  "children" : [ {
+    "_beagleComponent_" : "beagle:text",
+    "text" : "@{user.phoneNumber.cellphone}"
+  } ],
+  "context" : {
+    "id" : "user",
+    "value" : {
+      "cpf" : "014.225.235-12",
+      "phoneNumber" : {
+        "cellphone" : "(34) 98856-8563",
+        "telephone" : "(34) 3214-5588"
+      }
+    }
+  }
+}
+-->
+
+{{% playground file="bindingMultiValorados.json" language="pt" %}}
+{{% /tab %}}
+
+{{% tab name="Kotlin DSL" %}}
+No Kotlin é necessario que se crie algumas classes para gerenciar os contextos multivalorados
+
+```
+Container(
+        children = listOf(
+            Text("@{user.phoneNumber.cellphone}")
+        ),
+        context = ContextData(
+            id = "user",
+            value = User(
+                cpf = "014.225.235-12",
+                phoneNumber = PhoneNumber(
+                    cellphone = "(34) 98856-8563",
+                    telephone = "(34) 3214-5588"
+                )
+            )
+        )
+    )
+```
+
+```javascript
+data class User(val cpf: String, val phoneNumber:PhoneNumber)
+data class PhoneNumber(val cellphone:String, val telephone:String)
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+#### Binding com vetores \(arrays\)
+
+É o tipo de binding no qual o valor do contexto será, geralmente, vetores \(arrays\).
+
+Se um vetor é usado no valor do contexto para acessar uma posição especifica, você deve usar o caractere `[` e `]` quando estiver construindo um binding.
+
+Veja como no exemplo abaixo:
+
+Para acessar o título do segundo filme \("Contact"\), use o binding `@{movies.titles[1].title}`.
+
+{{< tabs id="T155" >}}
+{{% tab name="JSON" %}}
+
+<!-- json-playground:bindingVector.json
+{
+  "_beagleComponent_" : "beagle:container",
+  "children" : [ {
+    "_beagleComponent_" : "beagle:text",
+    "text" : "@{movies.titles[1].title}"
+  } ],
+  "context" : {
+    "id" : "movies",
+    "value" : {
+      "genre" : "sci-fi",
+      "titles" : [ {
+        "title" : "Inception",
+        "year" : "2010",
+        "rating" : "8.8"
+      }, {
+        "title" : "Contact",
+        "year" : "1997",
+        "rating" : "7.4"
+      } ]
+    }
+  }
+}
+-->
+
+{{% playground file="bindingVector.json" language="pt" %}}
+{{% /tab %}}
+
+{{% tab name="Kotlin DSL" %}}
+No Kotlin é necessário que se crie algumas classes para gerenciar os contextos multi-valorados
+
+```text
+Container(
+    children = listOf(
+        Text("@{movies.titles[1].title}")
+    ),
+    context = ContextData(
+        id = "movies",
+        value = Movie(
+            genre = "sci-fi",
+            titles = listOf(
+                Title(
+                    title = "Inception",
+                    year = "2010",
+                    rating = "8.8"
+                ),
+                Title(
+                    title = "Contact",
+                    year = "1997",
+                    rating = "7.4"
+                )
+            )
+        )
+    )
+)
+
+```
+
+```javascript
+class Movie(val genre: String, val titles:List<Title>)
+class Title(val title:String, val year:String, val rating:String)
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### O que acontece se eu atribuir um binding a uma variável que não existe?
+
+Bindings que se referem a **contextos não existentes ou inválidos** não podem ser atualizados e irão aparecer na tela da mesma forma que a string foi definida literalmente \(no caso, se o atributo recebido é uma string\).
+
+Por exemplo, se você usar `@{client.name}` e o `"client"` o contexto não é acessível \(declarado\), se o binding não for substituído por nenhum valor. O mesmo aconteceria se o contexto "client" não existisse, mas o tem a propriedade "name".
+
+### Bindings múltiplos em strings
+
+É possível usar mais de um binding em uma única string e eventos estáticos misturados com bindings.
+
+Veja como no exemplo abaixo:
+
+**Exemplo:** `"Hello @{person.name}. Your score is @{score.value}."`
+
+### Adicionando suporte para bindings em componentes customizados
+
+Em cada sistema, o binding deve ser declarado de uma forma:
+
+- **Android:** Todos os atributos recebem uma expressão que deve ser declarada como `Bind`.
+- **iOS:** Os atributos que recebem um binding devem ser declarados como `Expression` para fazer o mesmo efeito que no Android.
+- **Web:** Não é necessário lidar com bindings de uma maneira especial, o que significa que nada deve ser feito em seus componentes.
+
+Exemplos de cada sistema operacional:
+
+{{< tabs id="T156" >}}
+{{% tab name="Android" %}}
+
+```kotlin
+data class MyComponent(
+    val text: Bind<String>
+) : WidgetView() {
+
+    override fun buildView(rootView: RootView): View {
+        val view = MyView(rootView.getContext())
+        // To make bind works you have to call the observeBindChanges method
+        // passing a rootView and the attribute that has a bind
+        observeBindChanges(rootView, text) { view.setText(it) }
+        return view
+    }
+}
+```
+
+{{% /tab %}}
+
+{{% tab name="iOS" %}}
+
+```swift
+public struct MyComponent: Widget {
+    public var widgetProperties: WidgetProperties
+
+    public let text: Expression<String>
+
+    public func toView(renderer: BeagleRenderer) -> UIView {
+        let textView = UITextView()
+
+        // To make bind works you have to call the observeBindChanges method
+        // passing a rootView and the attribute that has a bind
+        renderer.observe(text, andUpdate: \.text, in: textView)
+
+        return textView
+    }
+}
+
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+A forma de referenciar uma expressão em Kotlin DSL é:
+
+{{< tabs id="T157" >}}
+{{% tab name="Kotlin DSL" %}}
+
+```kotlin
+MyComponent(
+  text = expressionOf("@{myContext.hello}")
+)
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+No entanto, caso você passe o **valor hardcoded**, você deve fazer dessa forma:
+
+{{< tabs id="T158" >}}
+{{% tab name="Kotlin DSL" %}}
+
+```kotlin
+MyComponent(
+  text = valueOf("hello")
+)
+```
+
+{{% /tab %}}
+{{< /tabs >}}

--- a/content/pt/api/screen/overview.md
+++ b/content/pt/api/screen/overview.md
@@ -1,0 +1,91 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: Descrição dos componentes de Screen e seus atributos.
+---
+
+---
+
+## O que é?
+
+A sua tela possui atributos e componentes que podem ser usados e configurados. Na tabela abaixo, listamos as principais características para cada um destes atributos.
+
+| **Atributo**           | **Tipo**                                                     | Obrigatório | **Definição**                                                                                                |
+| :--------------------- | :----------------------------------------------------------- | :---------: | :----------------------------------------------------------------------------------------------------------- |
+| identifier             | String                                                       |             | Atributo que identifica a tela globalmente na sua aplicação, de modo que seja possível atribuir ações a ela. |
+| safe area              | [**Safe Area**]({{< ref path="/api/screen/safe-area" lang="pt" >}})               |             | Especifica o posicionamento dos componentes na tela.                                                         |
+| navigation bar         | [**Navigation Bar**]({{< ref path="/api/screen/navigation-bar" lang="pt" >}})     |             | Permite configurar a barra de ações/navegação na tela.                                                       |
+| child                  | [**Server Driven Component**]({{< ref path="/api/components/" lang="pt" >}})      |      ✓      | Define os elementos na tela. Pode ser qualquer componente visual que estenda de `ServerDrivenComponent`.     |
+| style                  | [**Style**]({{< ref path="/api/widget#atributos-do-style" lang="pt" >}})          |             | Fornece opções de customização visual para a `Screen.`                                                       |
+| screen analytics event | [**Screen Event**]({{< ref path="/api/analytics#opção-screenview" lang="pt" >}}) |             | Configura elementos de análise\(Analytics\) na sua tela.                                                     |
+| context                | [**ContextData**]({{< ref path="/api/context/" lang="pt" >}})                     |             | Contexto da tela.                                                                                            |
+
+## Como usar?
+
+{{< tabs id="T174" >}}
+{{% tab name="JSON" %}}
+
+<!-- json-playground:screen.json
+{
+  "_beagleComponent_" : "beagle:screenComponent",
+  "navigationBar" : {
+    "title" : "Beagle Screen",
+    "showBackButton" : true,
+    "navigationBarItems" : [ {
+      "_beagleComponent_" : "beagle:navigationBarItem",
+      "text" : "",
+      "image" : {
+        "_beagleImagePath_" : "local",
+        "mobileId" : "informationImage"
+      },
+      "action" : {
+        "_beagleAction_" : "beagle:alert",
+        "title" : "Screen",
+        "message" : "Some message",
+        "labelOk" : "OK"
+      }
+    } ]
+  },
+  "child" : {
+    "_beagleComponent_" : "beagle:container",
+    "children" : [ {
+      "_beagleComponent_" : "beagle:text",
+      "text" : "Some text"
+    } ]
+  }
+}
+-->
+
+{{% playground file="screen.json" language="pt" %}}
+{{% /tab %}}
+
+{{% tab name="Kotlin DSL" %}}
+
+```kotlin
+Screen(
+        navigationBar = NavigationBar(
+            title = "Beagle Screen",
+            showBackButton = true,
+            navigationBarItems = listOf(
+                NavigationBarItem(
+                    text = "",
+                    image = Local.justMobile("informationImage"),
+                    action = Alert(
+                        title = "Screen",
+                        message = "Some message",
+                        labelOk = "OK"
+                    )
+                )
+            )
+        ),
+        child = Container(
+            children = listOf(
+                Text("Some text")
+            )
+        )
+    )
+```
+
+{{% /tab %}}
+{{< /tabs >}}

--- a/content/pt/get-started/creating-a-project-from-scratch/case-android/overview.md
+++ b/content/pt/get-started/creating-a-project-from-scratch/case-android/overview.md
@@ -1,0 +1,318 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: >-
+  Nesta seção, você encontra um passo a passo para iniciar um projeto Android
+  com Beagle.
+---
+
+---
+
+## Iniciando um projeto Android
+
+Para este exemplo prático, utilizaremos o Android Studio IDE. Caso você ainda não o tenha instalado, basta acessar no [**site oficial do Android** ](https://developer.android.com/studio?hl=us-en)e seguir as instruções.
+
+Depois de ter instalado o programa, siga os passos abaixo:
+
+**Passo 1:** Abra o Android Studio e clique em **Start a new Android Studio project**_._
+
+![](https://lh4.googleusercontent.com/bAhbvEZUN_pBXavMOqCvkt2Z4NlYsxXXtmeGRKEUnyGfuIm7c-mskMhmmiMbSaCw_xonW8vceVI2C27q08-k5tV8EDD5ymvoaPwDDFGe_fN3bmoqCQEoAAKASKXOTiI3KUPI1GQ1)
+
+**Passo 2:** Selecione a opção **Empty Activity** e clique em **next**.
+
+![](https://lh5.googleusercontent.com/nT0zkr0W_Ark0ZZDR2eWtCtfnjC_Fm98VSwU3DgBQzcgh_DoqkYNvhINztNL460p0U2hnygJ5K_DhrZMZis0mqHD69QJgKimruICs4MnBnPO9m-m_2T6E1nWIXiOfaIe0iiCjIN3)
+
+**Passo 3️:** Nesta página, devemos listar algumas informações importantes:
+
+- Informe o nome do seu projeto. Neste exemplo, chamaremos de `BeagleApp`.
+- Selecione qual linguagem utilizará. Para o Beagle, devemos utilizar o`Kotlin`.
+- Selecione o **SDK mínimo 19**, já que qualquer SDK menor que este não será compatível.
+- Defina o **package** e a **Save location** de acordo com sua preferência.
+- Clique em **Next**.
+
+![](https://lh3.googleusercontent.com/m5jnbs4K5AdwQbA7YVn7fSgtVzw5S68yCbGTj_7-CYa9CGvMR-qFO5EQ4SaNehXYRmI4WOOnqA6JQouzW2QC0YMTpBq7kJSbi54yl0Q2emL_y2FizY3LyloLjuh_uDyf8WyVbodP)
+
+**Passo 4️:** Feitas as configurações anteriores, o Android levará um tempo pra construir o projeto porque estará sincronizando todas as dependências inicias para inicializar o projeto
+
+Quando a inicialização for concluída, você verá esta página:
+
+![](/shared/mainactivity.png)
+
+{{% alert color="success" %}}
+Parabéns, seu projeto foi criado no Android! Agora, você precisará configurar o Beagle, de acordo com os passos a seguir.
+{{% /alert %}}
+
+## Configurando o Beagle
+
+### **Passo 1:** Definir as dependências
+
+Para começar, você precisa configurar as dependências do Beagle no seu repositório. Isso pode ser feito utilizando as configurações abaixo e fazendo o download da biblioteca do Beagle.
+
+- Abra o seu projeto no Android Studio.
+- Localize o arquivo `Graddle scripts` no projeto.
+- Nele existem dois arquivos do com o nome `gradle`. Abra o primeiro cujo nome é `build.graddle(project:Beagle)`
+- Procure o bloco de código `allprojects` e configure as credenciais do `Maven` como listadas abaixo.
+
+```go
+// Add it in your root build.gradle at the end of repositories:
+allprojects {
+    repositories {
+        google()
+        jcenter()
+        // < 1.1.0
+        maven {
+            url 'https://dl.bintray.com/zupit/repo'
+        }
+        // >= 1.1.0
+        mavenCentral()
+    }
+}
+
+```
+
+- Feche o arquivo `build.graddle(project:Beagle)`
+
+Feito isso, devemos incluir o `kapt plugin` e o `Beagle` como dependências no `dependency manager`. Para isso, siga estas instruções:
+
+- Abra o arquivo `build.graddle(Module:app)`
+
+Perceba que alguns `plugins` já estão listados no começo desse arquivo como mostrado na figura abaixo
+
+- Em seguida, adicione a linha*`apply plugin: 'kotlin-kapt'`*
+
+![](/shared/implementacaogradle.png)
+
+Depois disso, você precisa adicionar algumas dependências. Para isso:
+
+- Procure neste arquivo que está mexendo o bloco de código `dependencies { }`:
+- Adicione a variável `ext.beagle_version` logo acima \(no caso, fora\) do escopo das dependências
+  - Versão atual do Beagle[![Maven Central](https://img.shields.io/maven-central/v/br.com.zup.beagle/android)](https://oss.sonatype.org/#nexus-search;gav~br.com.zup.beagle~android~~~~kw,versionexpand)
+
+Copie e cole as linhas abaixo dentro das dependências :
+
+- _implementation "br.com.zup.beagle:android:$beagle_version"_
+- _kapt "br.com.zup.beagle:android-processor:$beagle_version"_
+
+```go
+// Add in your app level dependency
+ext.beagle_version = "${beagle_version}"
+
+dependencies {
+    implementation "br.com.zup.beagle:android:$beagle_version"
+    kapt "br.com.zup.beagle:android-processor:$beagle_version"
+}
+```
+
+{{% alert color="info" %}}
+Insira a versão de release do Beagle no lugar de `${beagle.version}`, ou seja, coloque a versão do Beagle destacada em azul da badge acima, mas sem o **caracter v** que antecede os números de versão.
+
+Por exemplo: undefined-`ext.beagle.version = "0.2.8"`
+{{% /alert %}}
+
+Ao final destas configurações, o seu arquivo deverá estar assim:
+
+![](/shared/implementacaogradle2.png)
+
+###
+
+### Passo 2: Configurar o Android Manifest
+
+O próximo passo é atualizar o seu projeto no Android Manifest adicionando algumas linhas a este arquivo:
+
+1. A permissão de INTERNET para que sua aplicação seja capaz de acessar a internet. `<uses-permission android:name="android.permission.INTERNET" />`
+
+{{% alert color="info" %}}
+Se você tiver dificuldade para encontrar este ou qualquer arquivo, basta usar a ferramenta de busca do Android Studio.
+
+Para habilitá-la, aperte o botão**`SHIFT`**do seu teclado duas vezes e a interface de busca aparecerá . Feito isso, é só digitar `AndroidManifest` e o Android Studio o localizará.
+{{% /alert %}}
+
+```markup
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.beagleexamples">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        ...
+        android:usesCleartextTraffic="true"
+        ...
+```
+
+Uma dica é deixar este arquivo aberto porque vamos usá-lo de novo em outro momento.
+
+{{% alert color="warning" %}}
+
+- O**`usesCleartextTraffic:`** indica que o aplicativo pretende usar o tráfego de rede de texto não criptografado, HTTP. O valor padrão para aplicativos que visam o nível de API 27 ou inferior é **`true`**. Os aplicativos que têm como alvo o nível de API 28 ou superior são padronizados como **`false`**.
+- O atributo **`android: usesCleartextTraffic = "true"`** dentro da `tag` **`<application>`** é usado para se comunicar com o BFF local. Se você pretende `depurar` o projeto usando um BFF local, você pode usar essa configuração como uma etapa de configuração rápida.
+- No entanto, se você planeja transformar este exemplo em um aplicativo para `release`, recomendamos que você use o `networkSecurityConfig`, que você pode configurar usando as instruções na [**página de desenvolvedores do Android**](https://developer.android.com/training/articles/security-config).
+  {{% /alert %}}
+
+### Passo 3: Configurar Network, Cache e Logger
+
+Agora que seu projeto está criado, você deve fazer as configurações do **Beagle**. Para isso, siga os passos abaixo:
+
+{{% alert color="warning" %}}
+O `Beagle` não fornece uma configuração de ** Rede **, ** Cache ** e ** Logger ** padrão em seus componentes internos, sendo necessário implementá-los para que o Beagle funcione conforme o esperado. Você pode criar suas próprias configurações seguindo os exemplos abaixo:
+
+[**👉 Acesse Camada de rede:**]({{< ref path="/resources/customization/beagle-for-android/network-client" lang="pt" >}})
+
+[**👉 Acesse Gerenciar cache:**]({{< ref path="/resources/customization/beagle-for-android/manage-cache" lang="pt" >}})
+
+[**👉 Acesse Sistema de log:**]({{< ref path="/resources/customization/beagle-for-android/log-system" lang="pt" >}})
+
+{{% /alert %}}
+
+### Passo 4: Criar o AppBeagleConfig
+
+Em um próximo passo, você deve criar uma classe chamada `AppBeagleConfig`. Ela faz parte das configurações iniciais do Beagle e é nela que vamos registrar algumas configurações importantes.
+
+Ao criá-la, devemos garantir que ela esteja configurada da seguinte forma:
+
+- Anotada com o `@BeagleComponent`
+- E deve `estender (extend)` da classe`BeagleConfig`
+
+Para criar o AppBeagleConfig, siga estes passos:
+
+1. Primeiro vamos criar o pacote que conterá nossos arquivos de configuração.
+2. Clique com botão direito do mouse no pacote principal do seu projeto e click em **new &gt; package** \_\_conforme a figura abaixo:
+
+![](/shared/newpackage.png)
+
+Embora você possa nomeá-lo como preferir, sugerimos que para este tutorial você use o nome`beagle`
+
+    3. Clique com o botão direito do mouse no pacote beagle e clique em **new&gt;Kotlin File/Class**
+
+**4. **Nomeie como `AppBeagleConfig` e pressione **`ENTER`**
+
+5.  Copie e cole as configurações abaixo no arquivo `AppBeagleConfig` que acabou de criar. Perceba que ele implementará os atributos: `baseUrl, environment, isLoggingEnabled, cache.`
+
+- O **`baseUrl`** retorna a URL base do seu ambiente.
+- O **`environment`** retorna o _`current build state`_ da sua aplicação.
+- O **`isLoggingEnabled`** retorna a visualização de log da aplicação.
+- O **`cache`** retorna a configuração de gerenciamento de cache.
+
+```kotlin
+import br.com.zup.beagle.android.annotation.BeagleComponent
+import br.com.zup.beagle.android.setup.BeagleConfig
+import br.com.zup.beagle.android.setup.Cache
+import br.com.zup.beagle.android.setup.Environment
+
+@BeagleComponent
+class AppBeagleConfig : BeagleConfig {
+    override val baseUrl: String get() = "http://10.0.2.2:8080" // return the base url based on your environment
+    override val environment: Environment get() = Environment.DEBUG // return the current build state of your app
+    override val isLoggingEnabled: Boolean = true
+    override val cache: Cache get() = Cache(
+        enabled = true, // If true, we will cache data on disk and memory.
+        maxAge = 300, // Time in seconds that memory cache will live.
+        memoryMaximumCapacity = 15 // Memory LRU cache size. It represents number of screens that will be in memory.
+    ) // Cache management configuration
+}
+```
+
+{{% alert color="info" %}}
+A partir deste ponto do tutorial, iremos testar nossas telas Server-Driven usando o local host. Por isso, é importante que nossa**`baseURL`** seja o seu local host.
+
+Outro ponto de atenção é que, neste momento, o Beagle espera que classes anotadas com `@BeagleComponent` tenham seus construtores vazios.
+{{% /alert %}}
+
+### Passo 5: BeagleActivity
+
+O Beagle oferece uma `Activity` padrão para gerenciar todas as `server-driven activities` que recebe. No entanto, é possível criar uma activity mais específica para lidar com determinados componentes server-driven de forma diferente. Você criará essa nova activity herdando de `BeagleActivity` e anotando-a com` @BeagleComponent`. Para mais detalhes sobre como criar essa classe, clique em [**Beagle Activity Customizada**]({{< ref path="/resources/customization/beagle-for-android/custom-beagle-activity" lang="pt" >}})
+
+{{% alert color="info" %}}
+{{% /alert %}}
+
+### Passo 6: Inicializar o Beagle e o Design System
+
+{{% alert color="info" %}}
+Importante! O que é o Design System?
+
+É o **design system** que guarda os registros dos componentes de estilo criados no frontend e é assim que sua aplicação Android “saberá” qual componente de estilo deve aplicar a cada elemento de uma tela Server-Driven. É na tela server driven que os elementos visuais \(views\) são utilizados na construção da sua tela.
+
+Embora você possa criá-lo agora se quiser, não é necessário para as configurações iniciais, para que você possa testar logo o Beagle! Você pode prosseguir sem configurá-lo. Mas saiba que o Design System é o pulmão da aplicação server-driven!
+
+[**Design System no Beagle para Android**.]({{< ref path="/get-started/creating-a-project-from-scratch/case-android/design-system-with-beagle-android" lang="pt" >}})
+{{% /alert %}}
+
+Agora, você deve inicializar sua `Application` para que o Beagle gere os outros arquivos de configuração que necessita. Para isso, basta clicar em`Make project` \(símbolo de MARTELO\) ou use o comando `CTRL + F9`.
+
+![](/shared/apppackage.png)
+
+Ao ser inicializado, o Beagle irá criar automaticamente o arquivo `BeagleSetup`, que estará na pasta de arquivos gerados como mostrado na figura abaixo:
+
+![](/shared/image%20%2843%29.png)
+
+### Passo 7: Criar a classe AppApplication
+
+Nesta etapa, você precisa criar uma classe`KOTLIN` que estenda da classe `Application`. Neste exemplo, vamos nomeá-la de `AppApplication`.
+
+É preciso realizar algumas configurações para que a pasta cumpra seu papel de chamar a função `BeagleSetup().init(this)` em seu método `onCreate`. Siga os passos abaixo:
+
+1. Clique com o botão direito do mouse no pacote principal do seu projeto _\(_**beagleapp**_\)_ e selecione:
+   - `new` &gt; `Kotlin file/class`
+   - Nomeie o arquivo como `AppApplication` e aperte **`enter`**
+   - Configure-a como no exemplo abaixo:
+
+```kotlin
+class AppApplication: Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        BeagleSetup().init(this)
+    }
+}
+```
+
+2. Para finalizar a implementação, você deve declarar a classe no **Android Manifest** que criamos no começo e que já está aberto.
+
+O nome da sua`application` agora é o nome desta classe que você criou. Faça o update do Android Manifest como indicado abaixo:
+
+```markup
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.beagleexamples">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:name=".beagle.AppApplication"
+
+        ...
+```
+
+{{% alert color="success" %}}
+Pronto, a sua aplicação Android está configurada e preparada para usar o Beagle!
+{{% /alert %}}
+
+Tudo o que você precisa agora é [**configurar um backend** ]({{< ref path="/get-started/creating-a-project-from-scratch/case-backend" lang="pt" >}})para responder as requisições da sua aplicação. Feita esta configuração, inicie a sua aplicação e você verá sua primeira tela server-driven!
+
+### Passo 8: Exibir sua Tela Server-Driven
+
+É muito simples exibir uma tela server-driven. Agora que toda a configuração do Beagle está pronta, você precisa seguir estes passos:
+
+- Abra o arquivo `MainActivity.kt`
+- Declare o `intent` como listado abaixo. Ele vai definir o endereço que tem as informações da sua tela no backend que você configurou.
+- Copie e cole o `intent` listado abaixo no método `onCreate`.
+
+```text
+val intent = this.newServerDrivenIntent<AppBeagleActivity>(ScreenRequest("/screen"))
+startActivity(intent)
+finish()
+```
+
+- Sua`MainActivity.kt` deve ficar assim:
+
+![](/shared/print-intent%20%282%29.png)
+
+Agora basta somente clicar em **`Run app`** e checar sua tela no emulador!  
+Você verá esta tela:
+
+![](/shared/captura-de-tela-2020-06-22-a-s-11.41.12.png)
+
+{{% alert color="success" %}}
+Parabéns, você criou sua primeira tela com Beagle! 🎉
+{{% /alert %}}

--- a/content/pt/get-started/creating-a-project-from-scratch/case-ios/overview.md
+++ b/content/pt/get-started/creating-a-project-from-scratch/case-ios/overview.md
@@ -1,0 +1,140 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: "Nesta seção, você encontra informações para iniciar um projeto iOS com Beagle."
+---
+
+---
+
+## Iniciando um projeto iOS
+
+Para criar um projeto iOS no Beagle, você primeiro precisa ter o Xcode instalado. Caso ainda não o tenha instalado ainda, faça o [**download na Mac App Store**](https://apps.apple.com/app/xcode/id497799835).
+
+Antes de começar, você primeiro precisar criar um projeto no `Xcode`. Para isso, basta abrir o programa e nomear o seu projeto. Para este exemplo, colocaremos como **Beagle Sample.**
+
+![](/shared/captura-de-tela-2020-04-08-a-s-10.35.19.png)
+
+Após criar o seu projeto, precisaremos adicionar as dependências. Para isso, usaremos o gerenciador `CocoaPods`.
+
+{{% alert color="info" %}}
+Se você tem alguma dúvida sobre como usar este gerenciador, sugerimos checar a [**documentação oficial do Cocoa Pods**](https://cocoapods.org/).
+{{% /alert %}}
+
+### Passo 1: Configurar o Cocoa Pods
+
+Você usará o terminal para instalar o `CocoaPods,` para isto abra o terminal e digite _`sudo gem install cocoapods`_
+
+```bash
+sudo gem install cocoapods
+```
+
+Para configurá-lo, navegue até sua pasta pelo terminal e digite o comando: _`pod init`_
+
+```swift
+pod init
+```
+
+Depois, abra o folder do projeto usando o comando: _`open .`_
+
+```swift
+open .
+```
+
+Feito isso, você deve selecionar o arquivo _`podfile`_ assim como apresentado na imagem abaixo:
+
+![](https://lh3.googleusercontent.com/3zzsq_UBccpGCwaMfyYGC6KR9v4Dj4GD3LO311IOBocCIlj6N9kLiw8M6M6liCf3RnICjHpZL9Grw0JgylSSdp1jTkun-N8UYazKu7Wy0jkvBBohE6biktoz932oNFZpnf8hLrJK)
+
+Abra o arquivo e adicione as seguintes dependências:
+
+```swift
+target 'Beagle Sample' do
+    pod 'Beagle'
+    pod 'YogaKit', :git => 'https://github.com/ZupIT/YogaKit'
+end
+```
+
+Abra novamente o terminal e digite o comando: _`pod install`_ para que as dependências sejam instaladas.
+
+```swift
+pod install
+```
+
+Depois da instalação, você deve abrir o arquivo que possui a extensão **`workspace.`** Neste exemplo, nós o chamaremos de `Beagle Sample.workspace`
+
+![](/shared/captura-de-tela-2020-04-08-a-s-10.23.09.png)
+
+### Passo 2: Configurar o Beagle
+
+Agora que seu projeto está criado, você deve fazer as configurações do **Beagle**. Para isso, siga os passos abaixo:
+
+1. Crie uma classe chamada`BeagleConfig` .
+
+Esta classe será responsável por conter parte da configuração inicial do Beagle. Nela, implementaremos uma função estática **`config`** para aplicar essas configurações.
+
+2. Nesta função crie uma constante chamada **`dependency`** que deve ser do tipo **`BeagleDependencies`**.
+
+A esta constante serão atribuídas algumas configurações do projeto, como por exemplo, listar a URL base que lista o `JSON` a ser utilizado na construção de uma tela server-driven. Para configurar esta constante, use o exemplo abaixo:
+
+```swift
+import Beagle
+import Foundation
+
+class BeagleConfig {
+    static func config() {
+
+        let dependencies = BeagleDependencies()
+        dependencies.urlBuilder = UrlBuilder(
+            baseUrl: URL(string: "http://localhost")
+        )
+        Beagle.dependencies = dependencies
+    }
+}
+```
+
+Agora, vamos configurar a classe **`SceneDelegate`** para que possamos inicializar nossa aplicação com o Beagle a partir de uma tela via [**BFF**:]({{< ref path="/key-concepts#backend-for-frontend" lang="pt" >}})
+
+- Crie a constante **`beagleScreen`**, que irá receber a tela server-driven.
+- O argumento `init URL` deve conter o endereço da [**URL relativa**]({{< ref path="/resources/urls#caminho-relativo" lang="pt" >}}) que será criada no backend \(BFF\). No nosso exemplo a chamaremos de "/screen"
+
+Siga o exemplo abaixo:
+
+```swift
+let beagleScreen = Beagle.screen(.remote(.init(url: "/screen")))
+window = UIWindow(frame: UIScreen.main.bounds)
+window?.windowScene = windowScene
+window?.rootViewController = beagleScreen
+window?.makeKeyAndVisible()
+```
+
+Ao final, a classe **`SceneDelegate`** deve ficar assim:
+
+![](https://lh5.googleusercontent.com/JcpliGK0G3QJyLlZIDcwD8X7TZfO7QKEjCcVmWNjX0NHoS8gHl8XOZrSg6dfVntZkusNGmJxRWTa3Ps_xrhCQsIQPOzsFZ375uLqDx1qvuWJWeOnlnQkQy8EkcvMuWhJ6KU8tF-r)
+
+### Passo 3: Configurar o Xcode
+
+Inicialmente, as propriedades do Xcode estão configuradas para que sua aplicação seja iniciada via `main.storyboard`. No entanto, agora quem deve iniciar a aplicação é o Beagle e, para que isso ocorra, devemos mudar essas propriedades **apagando** **as** **referências** ligadas ao `main.storyboard`.
+
+Estas referências estão no main project file, na**`Info tab`**, e estão assim organizadas:
+
+A primeira fica na sessão:  
+_**Custom iOS Target Properties**_ _**&gt;  
+`Main storyboard file base name`**_
+
+A segunda fica na sessão:  
+_**`Application Scene Manifest>`**_  
+_**`Scene Configuration`&gt;**_  
+_**`Application Session Role` &gt;  
+`Item 0 (Default Configuration)`&gt;  
+`Storyboard name`**_.
+
+No GIF abaixo, você vê melhor como remover as referências:
+
+![](/shared/main%20%282%29.gif)
+
+Feito! O Beagle está configurado na sua aplicação iOS. Agora, tudo o que você precisa é [**configurar um backend**]({{< ref path="/get-started/creating-a-project-from-scratch/case-backend" lang="pt" >}}) para responder as requisições do seu aplicativo server-driven.
+
+Feita essa configuração, inicie a sua aplicação e você terá sua primeira tela server-driven!  
+Você verá a tela a seguir:
+
+![](/shared/captura_de_tela_2020-04-07_a-s_17-removebg-preview-2-.png)

--- a/content/pt/get-started/using-beagle-helpers/Android/overview.md
+++ b/content/pt/get-started/using-beagle-helpers/Android/overview.md
@@ -1,0 +1,34 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: 'Aqui você encontrará bibliotecas que te auxiliarão iniciar um projeto usando o beagle para Android. Essas bibliotecas irão facilitar a configuração inicial do Beagle em um projeto, evitando algumas etapas e iniciando os estudos mais rapidamente.'
+---
+
+---
+
+![Maven Central](https://img.shields.io/maven-central/v/br.com.zup.beagle/beagle-scaffold?color=green&label=Beagle-Scaffold)
+![Maven Central](https://img.shields.io/maven-central/v/br.com.zup.beagle/beagle-defaults?color=green&label=Beagle-Defaults)
+![Maven Central](https://img.shields.io/maven-central/v/br.com.zup.beagle/android?label=Beagle)
+
+<hr>
+
+### Primeiros Passos
+
+Para começar a utilizar o beagle, você pode usar como auxilio as bibliotecas abaixo:
+* [Beagle-Scaffold](https://github.com/ZupIT/beagle-helpers/tree/main/android/beagle-scaffold):
+Esta biblioteca irá manter quase todas as configurações necessárias para começar a usar o Beagle em seu projeto.
+Aconselhamos o uso dessas bibliotecas para pessoas que nunca usaram o Beagle antes.
+
+* [Beagle-Defaults](https://github.com/ZupIT/beagle-helpers/tree/main/android/beagle-defaults):
+Esta biblioteca irá manter quase todas as configurações necessárias para começar a usar o Beagle em seu projeto.
+Aconselhamos o uso dessas bibliotecas para pessoas que nunca usaram o Beagle antes. Essas configurações incluem
+classes HttpClient, Logger e Cache padrão.<br>
+Todos estes também estão disponíveis na biblioteca Scaffold acima.
+
+
+{{% alert color="warning" %}}
+Se você deseja usar o Beagle para um aplicativo em produção, recomendamos que você configure um projeto
+ do zero usando nossa
+ [**documentação**]({{< ref path="/get-started/creating-a-project-from-scratch/case-android/" lang="pt" >}})
+{{% /alert %}}

--- a/content/pt/get-started/using-beagle-helpers/iOS/overview.md
+++ b/content/pt/get-started/using-beagle-helpers/iOS/overview.md
@@ -1,0 +1,29 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: 'Aqui você encontrará bibliotecas que irão te ajudar quando quiser começar um projeto usando o Beagle para iOS. Essas bibliotecas irão facilitar muito as configurações iniciais do Beagle em um projeto, pulando algumas etapas e começando os estudos mais rapidamente.'
+---
+
+---
+
+![Cocoapods](https://img.shields.io/cocoapods/v/BeagleScaffold?label=Beagle-Scaffold)
+![Cocoapods](https://img.shields.io/cocoapods/v/BeagleDefaults?label=Beagle-Defaults)
+![Cocoapods](https://img.shields.io/cocoapods/v/Beagle?label=Beagle)
+
+### Primeiros Passos
+<hr>
+
+Pra começar a usar o Beagle agora, você pode usar as bibliotecas abaixo:
+
+* [Beagle-Scaffold](https://github.com/ZupIT/beagle-helpers/tree/main/iOS/beagle-scaffold):
+Essa biblioteca vai conter quase todas as configurações necessárias pra começar a usar o Beagle no seu projeto. Nós aconselhamos o uso dessa biblioteca apenas pra usuários que nunca usaram o Beagle antes.
+
+* [Beagle-Defaults](https://github.com/ZupIT/beagle-helpers/tree/main/iOS/beagle-defaults):
+Essa biblioteca já é mais indicada pra usuários de Beagle mais experientes e vai conter apenas algumas classes com configurações necessárias pra usar o Beagle em uma aplicação. Dentre essas configurações temos uma camada padrão de Rede, Log e Cache. Todas elas também estão disponíveis na biblioteca Scaffold acima.
+
+{{% alert color="warning" %}}
+Se você deseja usar o Beagle para um aplicativo em produção, recomendamos que você configure um projeto
+ do zero usando nossa
+ [**documentação**]({{< ref path="/get-started/creating-a-project-from-scratch/case-ios/" lang="pt" >}})
+{{% /alert %}}

--- a/content/pt/get-started/using-beagle/WEB/overview.md
+++ b/content/pt/get-started/using-beagle/WEB/overview.md
@@ -1,0 +1,16 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: >-
+  Nesta seção, você encontra o passo a passo da configuração de uso do Beagle na
+  sua aplicação web, seja para Angular ou React.
+---
+
+---
+
+No caso do Beagle para Web, é necessário fazer as configurações de uso de acordo com o framework que estiver utilizando:
+
+{{% alert color="info" %}}
+Caso queira utilizar um BFF, é necessário ter um CORS configurado. Veja como fazer isso nas [**configurações de uso para backend**]({{< ref path="/get-started/using-beagle/backend#cors" lang="pt" >}}).
+{{% /alert %}}

--- a/content/pt/get-started/using-beagle/overview.md
+++ b/content/pt/get-started/using-beagle/overview.md
@@ -1,0 +1,14 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: >-
+  Nesta seção, você encontra um passo a passo para fazer as configurações de uso
+  do Beagle no seu projeto.
+---
+
+---
+
+Depois de fazer a [**instalação do Beagle**]({{< ref path="/get-started/installing-beagle/" lang="pt" >}}), é necessário realizar as configurações de uso para habilitar a ferramenta no seu projeto.
+
+Você pode configurar de acordo com a plataforma que estiver utilizando:

--- a/content/pt/playground/playground-web/overview.md
+++ b/content/pt/playground/playground-web/overview.md
@@ -1,0 +1,26 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: >-
+  Nesta seção, você encontra mais informações sobre a funcionalidade do
+  Playground para web.
+---
+
+---
+
+### O **que é o Playground?**
+
+O Playground é uma ferramenta de desenvolvimento onde se pode  criar componentes e páginas utilizando o Beagle de forma simples e rápida, sem a necessidade de fazer qualquer instalação. Ele possui uma interface que permite você escrever um JSON e ver o resultado de forma instantânea.
+
+### Acessando **o Playground**
+
+O playground pode ser acessado pelo **seguinte link**:
+
+{% embed url="https://beagle-playground.netlify.app" %}}
+
+Você terá acesso ao seguinte projeto demo:
+
+![](/shared/image%20%2827%29.png)
+
+O menu de arquivos fica à esquerda, no centro fica o JSON do arquivo selecionado, e a direita é onde você pode ver o preview do JSON selecionado.

--- a/content/pt/resources/cache/overview.md
+++ b/content/pt/resources/cache/overview.md
@@ -1,0 +1,56 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: Como o Beagle armazena elementos em cache entre o backend (BFF) e o frontend
+---
+
+---
+
+Atualmente, existem **duas camadas de cache** no Beagle:
+
+- Uma camada volátil
+- Uma camada persistente.
+
+A camada volátil hoje depende da camada persistente, no sentido que apenas itens cacheadas na camada persistente são candidatos para o cache volátil.
+
+## Camadas de cache
+
+### Cache volátil
+
+É o cache que fica na memória da aplicação frontend e que é usado para reduzir a quantidade de chamadas ao backend.
+
+As entradas nesta camada do cache têm duração por tempo, definida nas configurações gerais de cache de cada plataforma de cliente.
+
+Você pode checar como **configurar o cache** de acordo com sua plataforma, no link abaixo:
+
+- [**Configurando o cache**]({{< ref path="/resources/cache/how-to-configure-cache#configurando-e-customizando-o-cache" lang="pt" >}})
+
+### Cache persistente
+
+Nesta camada de cache, existem duas localizações. São elas:
+
+- Na memória do backend;
+- No armazenamento do frontend.
+
+Este cache é usado para otimizar a resposta do BFF - tanto em tempo quanto em tamanho -, em casos que não há mudança. As entradas neste cache duram até o servidor refazer o deploy ou o cliente ser reinstalado.
+
+A premissa para que este cache funcione é que ele deve sempre retornar o mesmo JSON para a mesma requisição. Para que uma requisição seja considerada igual, é necessário que tenha o mesmo endpoint e a mesma plataforma especificada como mostra nossa [**especificação de plataformas**.]({{< ref path="/resources/components/platform-sorting" lang="pt" >}})
+
+{{% alert color="danger" %}}
+É importante destacar que o mecanismo de cache **não deve** ser utilizado em **endpoints** que não atendam a essa **premissa**. Ele pode ser ativado ou desativado no BFF por endpoint ou para o BFF inteiro.
+{{% /alert %}}
+
+## Como o protocolo de cache funciona?
+
+O protocolo atua no cabeçalho `beagle-hash`. O BFF, por sua vez, valida os hashes recebidos e envia uma resposta completa ou apenas o `status HTTP 304 Not Modified` \(sem um corpo\).
+
+Quando o BFF responde com o `status 304`, o aplicativo carrega do elemento em cache. Caso isto não aconteça, ele armazena os dados recebidos \(hash e JSON\) e renderiza os elementos.
+
+![](/shared/beaglesave.png)
+
+## Próximos passos
+
+👉 Veja como fazer as [**configurações de cache**]({{< ref path="/resources/cache/how-to-configure-cache#configurando-e-customizando-o-cache" lang="pt" >}}) de acordo com cada plataforma \(Android, iOS, Web e Backend\).
+
+👉Confira o [**funcionamento do cache**]({{< ref path="/resources/cache/how-to-configure-cache#como-funciona-o-cache" lang="pt" >}}) de acordo com seus tipos \(confiável e não confiável\)

--- a/content/pt/resources/components-positioning/overview.md
+++ b/content/pt/resources/components-positioning/overview.md
@@ -1,0 +1,131 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: >-
+  Nesta seção, você encontra mais informações sobre o posicionamento dos
+  componentes na tela de um dispositivo usando Beagle.
+---
+
+---
+
+{{% alert color="warning" %}}
+
+#### Disponibilidade: Beagle 1.0+
+
+{{% /alert %}}
+
+## **Introdução**
+
+No Beagle, você terá de usar uma dependência chamada[ **Yoga Layout**](https://yogalayout.com/pt/) para posicionar os componentes na tela da sua aplicação.
+
+Para fazer isso, o Yoga faz os cálculos necessários para posicionar os elementos e, depois disso, faz a sua renderização.
+
+## **Sobre o Yoga Layout**
+
+O Yoga é um framework Android e iOS desenvolvido pelo Facebook para posicionar views usando o conceito do Flexbox.
+
+O Flexbox organiza os elementos dentro de containers de forma dinâmica para que, independente das dimensões da sua aplicação, você possa manter um layout flexível.
+
+Alguns conceitos chave para entender o Flexbox são:
+
+- **Main Axis:** eixo horizontal
+- **Cross Axis:** eixo vertical
+- **Main Size:** tamanho da dimensão dos eixos.
+
+No caso do Main Size, é possível ter **3 tipos diferentes de dimensões:**
+
+1. **Cross Size:** Tamanho da dimensão cross axis.
+2. **Main Start and Main End:** Começo e o fim do main axis.
+3. **Cross Start and Cross End:** Começo e o fim do cross axis.
+
+**‌**Estes eixos dependem do valor atribuído à propriedade flex-direction para definir a orientação dos elementos em tela.
+
+Se esta propriedade receber o valor:
+
+- **row ou row-reverse:** o main axis do container será o horizontal e o cross axis será vertical.
+
+![Exemplo de yoga layout com row ou row-reverse](https://lh3.googleusercontent.com/YwCLX11cEtBYnUcVYIDy63Z_aoEA5rfErFyOKSOgxZA092HmcFO7ZwDKgKJ6Tmjr-J3m7aQgSYCn2p0QzSLO_NsibCWc7LCg9Y2xDjVXQ6BWyhIjYpB3tCdbKx-4CnrKG7tSzaqp)
+
+- **column ou column-reverse:** o main axis do container será vertical e o cross axis será horizontal.
+
+![Exemplo de yoga layout com column ou column-reverse](https://lh3.googleusercontent.com/AM1cTOExo5ux4V_2-HE6WItbPdTWHj-6CBwDXxo8mV0vZfw6WoxtWWOUtosLU_UTTAArH_pMm35geJE1HBfYjqT-DBshvLsUcjvCmVoQVdPSGTW8QCx8YJltIgC4Ad9cDKFu1dQ4)
+
+{{% alert color="info" %}}
+Importante ressaltar que o default do Beagle é o valor `column`ou seja, os elementos serão dispostos em colunas por padrão.
+{{% /alert %}}
+
+## Propriedades disponíveis
+
+A partir do Yoga Layout, você pode utilizar as seguintes propriedades para inserir, alterar ou eliminar componentes em tela:
+
+### **UnitValue**
+
+As propriedades **Basis, Size, Margin, Padding e Position** descritas acima recebem um `UnitValue` que espera um valor`Double`e um `UnitType`, que é um `enum`com as seguintes opções:
+
+| **UnitType** | Definição                                                        |
+| :----------- | :--------------------------------------------------------------- |
+| **REAL**     | Aplica o valor `Double`                                          |
+| **PERCENT**  | Aplica o valor `Double` em forma de percentual do tamanho do pai |
+| **AUTO**     | Segue o valor do pai. Exceto quando possui tamanho próprio       |
+
+Para as propriedades listadas abaixo, na Web, o `default` é `UnitType.AUTO`.
+
+O `UnitType.AUTO` pode ser usado nas frentes iOS, Android e Web de acordo com a tabela abaixo:
+
+<table>
+  <thead>
+    <tr>
+      <th style="text-align:center">Propriedade</th>
+      <th style="text-align:center">
+          <img src="../../.gitbook/assets/image (125).png" alt/>
+        iOS
+      </th>
+      <th style="text-align:center">
+          <img src="../../.gitbook/assets/image (126).png" alt/>
+        Android
+      </th>
+      <th style="text-align:center">
+          <img src="../../.gitbook/assets/image (122).png" alt/>
+        Web
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="text-align:center"><strong>Basis</strong>
+      </td>
+      <td style="text-align:center">&#x2714;</td>
+      <td style="text-align:center">&#x2714;</td>
+      <td style="text-align:center">&#x2714;</td>
+    </tr>
+    <tr>
+      <td style="text-align:center"><strong>Size</strong>
+      </td>
+      <td style="text-align:center"></td>
+      <td style="text-align:center"></td>
+      <td style="text-align:center">&#x2714;</td>
+    </tr>
+    <tr>
+      <td style="text-align:center"><strong>Margin</strong>
+      </td>
+      <td style="text-align:center"></td>
+      <td style="text-align:center"></td>
+      <td style="text-align:center">&#x2714;</td>
+    </tr>
+    <tr>
+      <td style="text-align:center"><strong>Padding</strong>
+      </td>
+      <td style="text-align:center"></td>
+      <td style="text-align:center"></td>
+      <td style="text-align:center">&#x2714;</td>
+    </tr>
+    <tr>
+      <td style="text-align:center"><strong>Position</strong>
+      </td>
+      <td style="text-align:center"></td>
+      <td style="text-align:center"></td>
+      <td style="text-align:center">&#x2714;</td>
+    </tr>
+  </tbody>
+</table>

--- a/content/pt/resources/customization/beagle-for-android/custom-action/overview.md
+++ b/content/pt/resources/customization/beagle-for-android/custom-action/overview.md
@@ -1,0 +1,24 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: >-
+  Nesta seção, você encontra a descrição de como criar uma ação customizada e
+  detalhes dos métodos que ela implementa.
+---
+
+---
+
+## Introdução
+
+Uma ação \(`Action`\) é um componente do Beagle que pode ser chamado por meio de eventos que são disparados por outros componentes \(inclusive outras ações\).
+
+O Beagle já possui algumas ações pré-definidas, no entanto é possível criar novas ações personalizadas.
+
+
+
+
+
+{{% alert color="danger" %}}
+É **obrigatória** a adição da tag `@Transient` para **todos os atributos** presentes nas classes que representarão as ações para que não sejam levados em conta na serialização e desserialização do componente.
+{{% /alert %}}

--- a/content/pt/resources/customization/beagle-for-android/custom-widget/overview.md
+++ b/content/pt/resources/customization/beagle-for-android/custom-widget/overview.md
@@ -1,0 +1,26 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: >-
+  Nesta seção, você encontra um exemplo de com criar um componente e um widget
+  customizado.
+---
+
+---
+
+## Introdução
+
+O Beagle já fornece alguns **widgets básicos** prontos que você pode utilizar para criar a interface dos componentes de sua aplicação server-driven. 
+
+No entanto, a sua aplicação pode precisar de componentes mais especializados \(Custom Views\) e, para torná-los "visíveis"  ao Beagle, você precisa criar um **widget específico** para ele. Dessa forma, você pode criar quantos novos componentes desejar, desde que sempre **torne as Views do seu aplicativo "visíveis" para o Beagle.**
+
+
+
+
+
+
+
+{{% alert color="danger" %}}
+É **obrigatória** a adição da tag `@Transient` para **todos os atributos** presentes nas classes que representarão os widgets para que não sejam levados em conta na serialização e desserialização do componente.
+{{% /alert %}}

--- a/content/pt/resources/customization/beagle-for-ios/custom-actions/overview.md
+++ b/content/pt/resources/customization/beagle-for-ios/custom-actions/overview.md
@@ -1,0 +1,16 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: >-
+  Nesta seção, você encontra a descrição de como criar uma ação customizada e
+  detalhes dos métodos que ela implementa.
+---
+
+---
+
+## Introdução
+
+Uma ação \(`Action`\) é um componente do Beagle que pode ser chamado por meio de eventos que são disparados por outros componentes \(inclusive outras ações\).
+
+O Beagle já possui algumas ações pré-definidas, no entanto é possível criar novas ações personalizadas.

--- a/content/pt/resources/customization/beagle-for-web/_index.md
+++ b/content/pt/resources/customization/beagle-for-web/_index.md
@@ -8,5 +8,4 @@ description: >-
 
 ---
 
-O Beagle possui essas principais classes para Web: [  
-](https://docs.usebeagle.io/v/v1.0-en/resources/customization/beagle-para-web/customized-actions)
+O Beagle possui essas principais classes para Web: [](https://docs.usebeagle.io/v/v1.0-en/resources/customization/beagle-para-web/customized-actions)

--- a/content/pt/resources/customization/overview.md
+++ b/content/pt/resources/customization/overview.md
@@ -1,0 +1,12 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: >-
+  Nesta seção, você encontra as páginas para acessar customizações específicas
+  por plataforma.
+---
+
+---
+
+O Beagle disponibiliza na sua biblioteca algumas customizações. Você pode conhecer melhor o processo para cada biblioteca nas próximas páginas:

--- a/content/pt/resources/style/overview.md
+++ b/content/pt/resources/style/overview.md
@@ -1,0 +1,12 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: >-
+  Nesta seção, você encontra os conceitos de estilização de acordo com a sua
+  plataforma.
+---
+
+---
+
+O Beagle disponibiliza na sua biblioteca o recurso de estilização de componentes. Você pode conhecer melhor o processo para cada sistema operacional nas próximas páginas:

--- a/content/pt/tutorials/adding-beagle-to-a-part-of-a-native-screen/overview.md
+++ b/content/pt/tutorials/adding-beagle-to-a-part-of-a-native-screen/overview.md
@@ -1,0 +1,15 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: 'Nesta seção, você verá como exibir um componente do Beagle em uma tela nativa.'
+---
+
+---
+
+Existem duas formas que os componentes do Beagle podem ser adicionados a sua aplicação:
+
+* Via BFF \(como um server driven componente\);
+* Como um componente declarativo no front end.
+
+Veja abaixo mais detalhes de como adicionar um componente Beagle a sua tela nativa:

--- a/content/pt/tutorials/test/overview.md
+++ b/content/pt/tutorials/test/overview.md
@@ -1,0 +1,104 @@
+---
+title: Visão Geral
+weight: 1
+type: overview
+description: 'Você vai encontrar nesta seção mais detalhes de testes do Beagle e de testes em aplicações com o Beagle.'
+---
+
+---
+
+## Testes Unitários
+
+Testes unitários **medem a funcionalidade do código** em sua menor fração ou unidade. O Beagle possui testes unitários embutidos e eles devem ser frequentemente revisados, atualizados ou adicionados para assegurar que importantes unidades de códigos sejam testadas.
+
+## Testes de Interface De Usuário
+
+O Beagle implementa seus próprios testes de interface de usuário para garantir que componentes de interface e seus comportamentos funcionem corretamente. 
+
+Esse tipo de teste pode ser aplicado para plataformas mobile e web e os principais frameworks usados são:
+- [Cucumber](https://cucumber.io/)
+- [Espresso](https://developer.android.com/training/testing/espresso)
+- [XCTest](https://developer.apple.com/documentation/xctest)
+- [Appium](http://appium.io/)
+- [Cypress](https://www.cypress.io/)
+
+## Testes Instrumentados Mobile
+
+Testes instrumentados, também conhecidos como testes unitários instrumentados, são testes que rodam em devices (aparelhos) reais ou em emuladores. Eles utilizam APIs para encaminhar (instrumentar \ orquestrar) instruções vindas do código de teste para o device ou emulador. Estes testes trazem mais fidelidade se comparados a testes unitários convencionais, porém sua execução é mais lenta. 
+
+Nos testes instrumentados do Beagle, as vezes um componente server-driven não tem um `ID`. Neste caso, nós adicionamos um elemento widget que referencia o componente e um `ID`, para que então possamos identificar o componente pelo `ID` programaticamente gerado.
+
+### Exemplo de Teste Instrumentado Mobile
+
+![](/shared/gif-teste.gif)
+
+Neste exemplo, o objetivo é realizar um teste instrumentado na plataforma Android utilizando o framework Espresso. Para isso, você deve verificar a funcionalidade de seleção e inserção de valores em um componente `text field`, que é server-driven. 
+
+```java
+@Test
+    public void TestSelectTextField() {
+        new BeagleRobot()
+            .checkViewContainsText("Beagle Sample")
+            .selectMenuOption()
+            .clickOnText("TextField")
+            .typeIntoTextField(0,0,"beagle")
+            ;
+    }
+```
+
+### Passo 1: Iniciar o teste
+
+Comece o teste validando se a aplicação foi devidamente aberta na página principal. Na função `checkViewContainsText`, confirme se o  `Header` foi apresentado na tela. 
+Como este componente não possui um ID propriamente dito, utilize o texto contido no `Header` para localizar essa `view` na página principal. Veja como no exemplo a seguir: 
+
+```java
+public BeagleTest checkViewContainsText(String text) {
+        onView(allOf(withText(text))).check(matches(isDisplayed()));
+        return this;
+}
+```
+
+### Passo 2: Apresentar o menu
+
+Após localizar o `Header`, o próximo passo é utilizar a `selectMenuOption` para selecionar o ícone "hambúrguer" e apresentar as opções do menu. Por ser um componente server-driven e não possuir um ID nesta implementação, você deve utilizar o posicionamento do componente para realizar a seleção. 
+
+Feito isso, busque pelo texto presente no `ContentDescription ("More options")` e, em seguida, o seu posicionamento na hierarquia do componente. Confira no exemplo: 
+
+```java
+public BeagleTest selectMenuOption() {
+        onView(allOf(withContentDescription("More options"), childAtPosition(childAtPosition(withId(R.id.action_bar), 1), 0))).perform(click());
+        return this;
+}
+```
+
+### Passo 3: Selecionar componente
+
+Neste passo, o teste irá clicar em um componente \(novamente localizado a partir do texto que contém\) chamado `text field`, que é um item do menu aberto no passo anterior.
+
+```java
+public BeagleTest clickOnText(final String text) {
+        onView(allOf(withText(text), isDisplayed())).perform(click());
+        return this;
+}
+```
+
+### Passo 3: Inserir o componente
+
+Neste último passo, insira um texto no componente `text field`. Uma vez que este componente não possui ID e nem um texto, ele será localizado pelo seu posicionamento na hierarquia dos componentes. Veja no exemplo a seguir: 
+
+```java
+public BeagleTest typeIntoTextField(int position1, int position2, String text) {
+        onView(allOf(childAtPosition(
+          childAtPosition(
+            withId(R.id.fragment_content), position1), position2)
+          )
+        ).perform(typeText(text));
+                
+        Espresso.closeSoftKeyboard();
+        return this;
+}
+```
+
+{{% alert color="success" %}}
+Pronto, o seu teste instrumentado foi realizado!
+{{% /alert %}}

--- a/layouts/overview/single.html
+++ b/layouts/overview/single.html
@@ -1,0 +1,17 @@
+{{ define "main" }}
+<div class="td-content">
+	<h1>{{ .Title }}</h1>
+	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	{{ .Content }}
+        {{ partial "overview-index.html" . }}
+	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
+		{{ partial "feedback.html" .Site.Params.ui.feedback }}
+		<br />
+	{{ end }}
+	{{ if (.Site.DisqusShortname) }}
+		<br />
+		{{ partial "disqus-comment.html" . }}
+	{{ end }}
+	<div class="text-muted mt-5 pt-3 border-top">{{ partial "page-meta-lastmod.html" . }}</div>
+</div>
+{{ end }}

--- a/layouts/partials/overview-index.html
+++ b/layouts/partials/overview-index.html
@@ -1,0 +1,17 @@
+<div class="section-index">
+    {{ $pages := (where .Site.Pages "Section" .Section).ByWeight }}
+    {{ $pages = .Site.Pages.ByWeight }}
+    {{ $parent := .Parent }}
+    {{ $page := . }}
+    <hr class="panel-line">
+    {{ range $pages }}
+        {{ if and (eq .Parent $parent) (ne . $page) }}
+            <div class="entry">
+                <h2>
+                    <a href="{{ .RelPermalink }}">{{- .Title -}}</a>
+                </h2>
+                <p>{{ .Description | markdownify }}</p>
+            </div>
+        {{ end }}
+    {{ end }}
+</div>


### PR DESCRIPTION
Adding a section overview to each section that has at least a phrase in its _index.md file.
* The information that was in _index.md was previously not accessible. Added an overview page to each section with relevant information to its _index.md
ex: the context _index.md had all context information and it was previously not accessible. Same with using beagle android and ios 